### PR TITLE
Fauzedev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ options.h
 url.h
 
 *.xcscheme
-
-nitrogen/Nitrogen.xcodeproj/xcuserdata/admin.xcuserdatad/xcschemes/xcschememanagement.plist
+xcuserdata/

--- a/MPRController.m
+++ b/MPRController.m
@@ -368,8 +368,6 @@ static float deg2rad = M_PI/180.0;
 
 - (void) showWindow:(id) sender
 {
-    [self applyViewsPosition];
-    
 	mprView1.dontUseAutoLOD = YES;
 	mprView2.dontUseAutoLOD = YES;
 	mprView3.dontUseAutoLOD = YES;
@@ -424,6 +422,8 @@ static float deg2rad = M_PI/180.0;
 	mprView3.dontUseAutoLOD = NO;
 	
 	[self setLOD: 1];
+    
+    [self applyViewsPosition];
 }
 
 -(void)splitViewWillResizeSubviews:(NSNotification *)notification


### PR DESCRIPTION
[0000019] Fixed - 3D MPR display error

applyViewsPosition will only work since the window is displayed. Hence,
the superclass method must be called before computing geometry of the
viewports.
