### PR TITLE
Cleaner API frameworks (Horos.framework)

### DIFF
--- a/Horos.xcodeproj/project.pbxproj
+++ b/Horos.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 			);
 			dependencies = (
 				4A2F590D078D124B00C514A2 /* PBXTargetDependency */,
-				9966A19D1AE09AFC00F2D81A /* PBXTargetDependency */,
 				AB0F3A421046BFB9004129DD /* PBXTargetDependency */,
 				9966A2E41AE0B8AF00F2D81A /* PBXTargetDependency */,
 				AB72503C0ADE6F7000A212A0 /* PBXTargetDependency */,
@@ -510,7 +509,7 @@
 		59EBFDDD12BA5A1B00809C61 /* WebPortal+Email+Log.mm in Sources */ = {isa = PBXBuildFile; fileRef = 59EBFDDB12BA5A1A00809C61 /* WebPortal+Email+Log.mm */; };
 		59EBFEA412BB500C00809C61 /* browserController.h in Headers */ = {isa = PBXBuildFile; fileRef = 59EBFEA212BB500C00809C61 /* browserController.h */; };
 		59F1A4C8104BA5BE009E3215 /* HorosHeaders.mm in Sources */ = {isa = PBXBuildFile; fileRef = 59F1A4C7104BA5BE009E3215 /* HorosHeaders.mm */; };
-		59F1A515104BA8AE009E3215 /* HorosAPI.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = AB0F3A2C1046BD2B004129DD /* HorosAPI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		59F1A515104BA8AE009E3215 /* Horos.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = AB0F3A2C1046BD2B004129DD /* Horos.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		59F5F3F911F476030047A90D /* N2ImageButtonCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 59F5F3F711F476030047A90D /* N2ImageButtonCell.h */; };
 		59F5F3FA11F476030047A90D /* N2ImageButtonCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 59F5F3F811F476030047A90D /* N2ImageButtonCell.mm */; };
 		59F5F4EC11F485CC0047A90D /* BrowserController+Activity.h in Headers */ = {isa = PBXBuildFile; fileRef = 59F5F4EA11F485CC0047A90D /* BrowserController+Activity.h */; };
@@ -755,9 +754,6 @@
 		992DD7761BCB095700369C09 /* libgdcmuuid.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 992DD75C1BCB095700369C09 /* libgdcmuuid.a */; };
 		9939F7A91BCB0BF8009FEB69 /* FVTiff.m in Sources */ = {isa = PBXBuildFile; fileRef = CEE73FC808F44724002A395F /* FVTiff.m */; };
 		9963031B1BCACF26009CE3E5 /* libGDCM.h in Headers */ = {isa = PBXBuildFile; fileRef = 9963031A1BCACF26009CE3E5 /* libGDCM.h */; };
-		9966A1901AE099A400F2D81A /* ViewerController.h in Headers */ = {isa = PBXBuildFile; fileRef = ABE17661056D2659009C93B5 /* ViewerController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9966A1911AE099A400F2D81A /* options.h in Headers */ = {isa = PBXBuildFile; fileRef = 434B46151A19F2A3008CF8CF /* options.h */; };
-		9966A19F1AE09B6F00F2D81A /* OsiriXHeaders.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9966A19E1AE09B6F00F2D81A /* OsiriXHeaders.mm */; };
 		9966A1A11AE09D3F00F2D81A /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9966A1A01AE09D3F00F2D81A /* AddressBook.framework */; };
 		9966A1A31AE09D4800F2D81A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9966A1A21AE09D4800F2D81A /* AVFoundation.framework */; };
 		9966A1A51AE09D5100F2D81A /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9966A1A41AE09D5100F2D81A /* CoreMedia.framework */; };
@@ -767,7 +763,6 @@
 		9966A1AC1AE09DB300F2D81A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9966A1A21AE09D4800F2D81A /* AVFoundation.framework */; };
 		9966A1AD1AE09DD000F2D81A /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9966A1A41AE09D5100F2D81A /* CoreMedia.framework */; };
 		9966A1AE1AE09DE200F2D81A /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9966A1AA1AE09D7C00F2D81A /* Quartz.framework */; };
-		9966A1B41AE0AC7400F2D81A /* OsiriXAPI.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 9966A19A1AE099A400F2D81A /* OsiriXAPI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9966A1B51AE0B6EE00F2D81A /* HorosDCM.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 844719AF0FD8EF50003BFDF8 /* HorosDCM.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9966A1BB1AE0B7E000F2D81A /* DCM.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E0B3A13067526A600908593 /* DCM.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9966A1BC1AE0B7E000F2D81A /* DCMAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E0B3A14067526A600908593 /* DCMAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2340,7 +2335,7 @@
 		A9FBD37316DBE3AA003A0E04 /* VR Red Vessels.plist in Resources */ = {isa = PBXBuildFile; fileRef = ABBA8D9B065AB90200A1F89C /* VR Red Vessels.plist */; };
 		A9FBD38316DBE701003A0E04 /* Growl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE2BE05D1524344D00AE6156 /* Growl.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		A9FBD38416DBE782003A0E04 /* Growl.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = CE2BE05D1524344D00AE6156 /* Growl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		A9FBD38616DBE821003A0E04 /* HorosAPI.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = AB0F3A2C1046BD2B004129DD /* HorosAPI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		A9FBD38616DBE821003A0E04 /* Horos.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = AB0F3A2C1046BD2B004129DD /* Horos.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A9FBD38716DBE83E003A0E04 /* ILCrashReporter.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = ABE881440FC1444D009F5C80 /* ILCrashReporter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A9FBD38816DBE84D003A0E04 /* libxerces-c.27.dylib in Copy Files */ = {isa = PBXBuildFile; fileRef = CE6693C60AF551210073D923 /* libxerces-c.27.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A9FBD38A16DBE855003A0E04 /* libdcmprintscu.dylib in Copy Files */ = {isa = PBXBuildFile; fileRef = CE586CC30C74B75D00DB7D5A /* libdcmprintscu.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -4590,13 +4585,6 @@
 			remoteGlobalIDString = 59BDEC2C117C92B2007F1F2C;
 			remoteInfo = "OsiriX Launcher";
 		};
-		9966A19C1AE09AFC00F2D81A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9966A18E1AE099A400F2D81A;
-			remoteInfo = "OsiriX API";
-		};
 		9966A2E31AE0B8AF00F2D81A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
@@ -4647,7 +4635,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				A9FBD38616DBE821003A0E04 /* HorosAPI.framework in Copy Files */,
+				A9FBD38616DBE821003A0E04 /* Horos.framework in Copy Files */,
 				A9FBD38416DBE782003A0E04 /* Growl.framework in Copy Files */,
 				A9FBD38816DBE84D003A0E04 /* libxerces-c.27.dylib in Copy Files */,
 				A9FBD38716DBE83E003A0E04 /* ILCrashReporter.framework in Copy Files */,
@@ -4665,8 +4653,7 @@
 				999901A41B52B24200921EA1 /* libdcmprintscu.dylib in Copy Frameworks */,
 				999901A51B52B24200921EA1 /* libxerces-c.27.dylib in Copy Frameworks */,
 				9966A1B51AE0B6EE00F2D81A /* HorosDCM.framework in Copy Frameworks */,
-				59F1A515104BA8AE009E3215 /* HorosAPI.framework in Copy Frameworks */,
-				9966A1B41AE0AC7400F2D81A /* OsiriXAPI.framework in Copy Frameworks */,
+				59F1A515104BA8AE009E3215 /* Horos.framework in Copy Frameworks */,
 				CE04B81B15289AF400EF6E52 /* Growl.framework in Copy Frameworks */,
 				84F453570FC3DF5400D29666 /* ILCrashReporter.framework in Copy Frameworks */,
 			);
@@ -5355,7 +5342,6 @@
 		992DD75B1BCB095700369C09 /* libgdcmopenjpeg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libgdcmopenjpeg.a; sourceTree = "<group>"; };
 		992DD75C1BCB095700369C09 /* libgdcmuuid.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libgdcmuuid.a; sourceTree = "<group>"; };
 		9963031A1BCACF26009CE3E5 /* libGDCM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libGDCM.h; path = Binaries/GDCMHeaders/libGDCM.h; sourceTree = "<group>"; };
-		9966A19A1AE099A400F2D81A /* OsiriXAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OsiriXAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9966A19E1AE09B6F00F2D81A /* OsiriXHeaders.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OsiriXHeaders.mm; sourceTree = "<group>"; };
 		9966A1A01AE09D3F00F2D81A /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
 		9966A1A21AE09D4800F2D81A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -5604,7 +5590,7 @@
 		AB0DF7450FD79FEA00A7C57E /* dviface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dviface.h; path = "Binaries/dcmtk-source/dcmpstat/dviface.h"; sourceTree = SOURCE_ROOT; };
 		AB0EA93B056EDC7E004BBDD3 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
 		AB0F20AB06460F7F0075465D /* Burner.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Burner.icns; sourceTree = "<group>"; };
-		AB0F3A2C1046BD2B004129DD /* HorosAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HorosAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB0F3A2C1046BD2B004129DD /* Horos.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Horos.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB10FA221129302A009EB238 /* PopUpArrows.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = PopUpArrows.png; path = nitrogen/Resources/PopUpArrows.png; sourceTree = SOURCE_ROOT; };
 		AB10FA670B96C95500D74684 /* OsirixDownload.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = OsirixDownload.icns; sourceTree = "<group>"; };
 		AB10FA9F11293378009EB238 /* N2Debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = N2Debug.h; path = nitrogen/Sources/N2Debug.h; sourceTree = "<group>"; };
@@ -7234,13 +7220,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9966A1941AE099A400F2D81A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		9966A2D81AE0B7E000F2D81A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -7707,10 +7686,9 @@
 				AB724FF60ADE6ECB00A212A0 /* Decompress */,
 				CEDF6DD00B46FE99008B45B8 /* DICOMPrint */,
 				844719AF0FD8EF50003BFDF8 /* HorosDCM.framework */,
-				AB0F3A2C1046BD2B004129DD /* HorosAPI.framework */,
+				AB0F3A2C1046BD2B004129DD /* Horos.framework */,
 				59BDEC2D117C92B2007F1F2C /* Horos Launcher.app */,
 				A98795C216DB9FD100926023 /* Unit Tests.octest */,
-				9966A19A1AE099A400F2D81A /* OsiriXAPI.framework */,
 				9966A2E11AE0B7E000F2D81A /* OsiriX.framework */,
 			);
 			name = Products;
@@ -11241,15 +11219,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9966A18F1AE099A400F2D81A /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9966A1901AE099A400F2D81A /* ViewerController.h in Headers */,
-				9966A1911AE099A400F2D81A /* options.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		9966A1BA1AE0B7E000F2D81A /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -12222,25 +12191,6 @@
 			productReference = 844719AF0FD8EF50003BFDF8 /* HorosDCM.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		9966A18E1AE099A400F2D81A /* OsiriX API (Legacy) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9966A1971AE099A400F2D81A /* Build configuration list for PBXNativeTarget "OsiriX API (Legacy)" */;
-			buildPhases = (
-				9966A18F1AE099A400F2D81A /* Headers */,
-				9966A1921AE099A400F2D81A /* Sources */,
-				9966A1941AE099A400F2D81A /* Frameworks */,
-				9966A1951AE099A400F2D81A /* Copy Headers and Create Horos.h */,
-				9966A1961AE099A400F2D81A /* Code Signing */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "OsiriX API (Legacy)";
-			productName = "OsiriXHeaders Framework";
-			productReference = 9966A19A1AE099A400F2D81A /* OsiriXAPI.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		9966A1B91AE0B7E000F2D81A /* OsiriX DCM Framework (Legacy) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9966A2DE1AE0B7E000F2D81A /* Build configuration list for PBXNativeTarget "OsiriX DCM Framework (Legacy)" */;
@@ -12295,7 +12245,7 @@
 			);
 			name = "Horos API";
 			productName = "OsiriXHeaders Framework";
-			productReference = AB0F3A2C1046BD2B004129DD /* HorosAPI.framework */;
+			productReference = AB0F3A2C1046BD2B004129DD /* Horos.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		AB28B42E05B7921E00A9906C /* Horos */ = {
@@ -12310,7 +12260,7 @@
 				AB28B42D05B7921E00A9906C /* Frameworks */,
 				CECA66E306CD8C1500D8750E /* Copy Frameworks */,
 				ABF307FB1443330100BBC96A /* Copy odt2pdf script */,
-				59F69A4E1056328D008585F5 /* Clean Frameworks */,
+				59F69A4E1056328D008585F5 /* Clear API headers, create links for legacy API frameworks */,
 				847B929C15480BC400271A61 /* Create Resources Disabled folder */,
 				CE48FEFE181E486C00A0910B /* Git Hash */,
 				CED88262125064F70085A861 /* CodeSigning */,
@@ -12416,7 +12366,6 @@
 				4A2F58D8078D118700C514A2 /* Build All Prerequisites */,
 				BF7486A50CC6AA5C00198387 /* Documentation */,
 				A98795C116DB9FD100926023 /* Unit Tests */,
-				9966A18E1AE099A400F2D81A /* OsiriX API (Legacy) */,
 				9966A1B91AE0B7E000F2D81A /* OsiriX DCM Framework (Legacy) */,
 			);
 		};
@@ -13308,19 +13257,19 @@
 			shellPath = /bin/sh;
 			shellScript = "#cd \"${BUILT_PRODUCTS_DIR}\"\n#product=\"Horos Launcher.app\"\n#dest=\"${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Horos Launcher.zip\"\n#rm -f \"$dest\"\n#zip -qr \"$dest\" \"$product\"\n\n#product=\"$SRCROOT/Binaries/Horos Launcher.zip\"\n#cp \"$product\" \"${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"";
 		};
-		59F69A4E1056328D008585F5 /* Clean Frameworks */ = {
+		59F69A4E1056328D008585F5 /* Clear API headers, create links for legacy API frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Clean Frameworks";
+			name = "Clear API headers, create links for legacy API frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#set -x\n\n#################### Horos API\n\nheaderspath=\"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/HorosAPI.framework/Versions/A/Headers\"\nrm -Rf \"$headerspath\"\nmkdir -p \"$headerspath\"\nrm -Rf \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/HorosAPI.framework/Versions/A/Frameworks/Nitrogen.framework\"\n\nif [ \"$DEBUGGING_SYMBOLS\" == \"YES\" ] ; then\nrm -Rf \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/Nitrogen.framework/Versions/A/Nitrogen.framework.dSYM\"\nfi\n\nrm -Rf \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/Horos Headers.framework\"\n\ncd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH\"\nln -sf “HorosAPI.framework\" “Horos Headers.framework\"\n\ncd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/HorosAPI.framework\"\nln -sf “HorosAPI\" “Horos Headers\"\n\ncd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/HorosAPI.framework/Versions/A\"\nln -sf “HorosAPI\" “Horos Headers\"\n\n#################### OsiriX API\n\nheaderspath=\"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/OsiriXAPI.framework/Versions/A/Headers\"\nrm -Rf \"$headerspath\"\nmkdir -p \"$headerspath\"\nrm -Rf \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/OsiriXAPI.framework/Versions/A/Frameworks/Nitrogen.framework\"\n\nif [ \"$DEBUGGING_SYMBOLS\" == \"YES\" ] ; then\nrm -Rf \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/Nitrogen.framework/Versions/A/Nitrogen.framework.dSYM\"\nfi\n\nrm -Rf \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/OsiriX Headers.framework\"\n\ncd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH\"\nln -sf “OsiriXAPI.framework\" “OsiriX Headers.framework\"\n\ncd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/OsiriXAPI.framework\"\nln -sf “OsiriXAPI\" “OsiriX Headers\"\n\ncd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/OsiriXAPI.framework/Versions/A\"\nln -sf “OsiriXAPI\" “OsiriX Headers\"\n";
+			shellScript = "#set -x\n\nfunction fake_framework {\n    cd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH\"\n    ln -sf \"$1.framework\" \"$2.framework\"\n    cd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1.framework/Versions/Current\"\n    ln -sf \"$1\" \"$2\"\n    cd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1.framework\"\n    ln -sf \"Versions/Current/$1\" \"$2\"\n}\n\npath=\"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/Horos.framework/Versions/A/Headers\"\nrm -Rf \"$path\"\nmkdir -p \"$path\"\n\nfake_framework \"Horos\" \"HorosAPI\"\nfake_framework \"Horos\" \"OsiriXAPI\"\nfake_framework \"Horos\" \"OsiriX Headers\"\n\ncd \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH\"\nrm -Rf \"Horos.framework/Horos.framework\" # this is odd... the first ln in fake_framework creates this link :/\n\nexit 0";
 		};
 		7183153F161065BE0098576F /* Replace Weasis ext-config.properties */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -13350,34 +13299,6 @@
 			shellPath = /bin/sh;
 			shellScript = "mkdir -p \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/Resources Disabled/\"\nexit 0";
 		};
-		9966A1951AE099A400F2D81A /* Copy Headers and Create Horos.h */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Headers and Create Horos.h";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /usr/bin/perl;
-			shellScript = "#!/usr/bin/perl\n\nuse strict;\nuse File::Copy;\nuse File::Basename;\nmy $destination = \"$ENV{TARGET_BUILD_DIR}/$ENV{PUBLIC_HEADERS_FOLDER_PATH}\";\n\nmkdir $destination unless -d $destination;\nopen OsiriX_h, \">\", \"$destination/OsiriX.h\" or die $!;\n\nprint OsiriX_h \"#ifndef __OsiriX_API\\n#define __OsiriX_API\\n\\n\";\n\nmy @fromdirs = (\"$ENV{PROJECT_DIR}/cocoahttpserver\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/config\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/dcmsr\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/dcmdata\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/ofstd\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/dcmnet\", \"$ENV{PROJECT_DIR}/VTKHeaders\", \"$ENV{PROJECT_DIR}/Nitrogen/Sources\", \"$ENV{PROJECT_DIR}/Nitrogen/Sources/JSON\", $ENV{PROJECT_DIR});\n\nforeach my $root (@fromdirs) {\n    opendir(DIR, $root);\n    \n    my @files = readdir(DIR);\n    foreach (@files) {\n        my $filename = $_;\n        next unless -f \"$root/$filename\" && $filename =~ /\\.h$/s;\n        my @args = ( \"cp\", \"-fp\", \"$root/$filename\", \"$destination/\".(basename $filename) );\n        system(@args) == 0 or die \"Copy failed: $?\";\n        print OsiriX_h \"#include <OsiriXAPI/$filename>\\n\";\n    }\n    \n    closedir(DIR);\n}\n\nprint OsiriX_h \"\\n#endif\\n\";\nclose OsiriX_h;\n\nchdir \"$ENV{TARGET_BUILD_DIR}/$ENV{FULL_PRODUCT_NAME}\";\nsymlink \"Versions/Current/Headers\", \"Headers\";\n\nexit 0;";
-		};
-		9966A1961AE099A400F2D81A /* Code Signing */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Code Signing";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#test with codesign -vvv\n\nif [[ ${CONFIGURATION} == \"Deployment 32-bit\" ]]\nthen\n# -f means force to re-sign even if already signed\ncodesign -f -s \"Developer ID Application\" \"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/\"\necho \"code signed\"\nfi\n\nif [[ ${CONFIGURATION} == \"Deployment 64-bit\" ]]\nthen\n# -f means force to re-sign even if already signed\ncodesign -f -s \"Developer ID Application\" \"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/\"\necho \"code signed\"\nfi";
-		};
 		A98795C016DB9FD100926023 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -13403,7 +13324,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /usr/bin/perl;
-			shellScript = "#!/usr/bin/perl\n\nuse strict;\nuse File::Copy;\nuse File::Basename;\nmy $destination = \"$ENV{TARGET_BUILD_DIR}/$ENV{PUBLIC_HEADERS_FOLDER_PATH}\";\n\nmkdir $destination unless -d $destination;\nopen Horos_h, \">\", \"$destination/Horos.h\" or die $!;\n\nprint Horos_h \"#ifndef __Horos_API\\n#define __Horos_API\\n\\n\";\n\nmy @fromdirs = (\"$ENV{PROJECT_DIR}/cocoahttpserver\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/config\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/dcmsr\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/dcmdata\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/ofstd\", \"$ENV{PROJECT_DIR}/Binaries/dcmtk-source/dcmnet\", \"$ENV{PROJECT_DIR}/VTKHeaders\", \"$ENV{PROJECT_DIR}/Nitrogen/Sources\", \"$ENV{PROJECT_DIR}/Nitrogen/Sources/JSON\", $ENV{PROJECT_DIR});\n\nforeach my $root (@fromdirs) {\n\topendir(DIR, $root);\n\t\n\tmy @files = readdir(DIR);\n\tforeach (@files) {\n\t\tmy $filename = $_;\n\t\tnext unless -f \"$root/$filename\" && $filename =~ /\\.h$/s;\n\t\tmy @args = ( \"cp\", \"-fp\", \"$root/$filename\", \"$destination/\".(basename $filename) );\n\t\tsystem(@args) == 0 or die \"Copy failed: $?\";\n\t\tprint Horos_h \"#include <HorosAPI/$filename>\\n\";\n\t}\n\t\n\tclosedir(DIR);\n}\n\nprint Horos_h \"\\n#endif\\n\";\nclose Horos_h;\n\nchdir \"$ENV{TARGET_BUILD_DIR}/$ENV{FULL_PRODUCT_NAME}\";\nsymlink \"Versions/Current/Headers\", \"Headers\";\n\nexit 0;";
+			shellScript = "#!/usr/bin/perl\n\nuse strict;\nuse File::Copy;\nuse File::Basename;\nmy $destination = \"$ENV{TARGET_BUILD_DIR}/$ENV{PUBLIC_HEADERS_FOLDER_PATH}\";\n\nmkdir $destination unless -d $destination;\nopen Horos_h, \">\", \"$destination/Horos.h\" or die $!;\n\nprint Horos_h \"#ifndef __Horos_API\\n#define __Horos_API\\n\\n\";\n\nmy @fromdirs = (\"cocoahttpserver\", \"Binaries/dcmtk-source/config\", \"Binaries/dcmtk-source/dcmsr\", \"Binaries/dcmtk-source/dcmdata\", \"Binaries/dcmtk-source/ofstd\", \"Binaries/dcmtk-source/dcmnet\", \"VTKHeaders\", \"Nitrogen/Sources\", \"Nitrogen/Sources/JSON\", \"DCM Framework\", \"\");\n\nforeach my $root (@fromdirs) {\n    if ($root eq \"\") {\n        $root = $ENV{PROJECT_DIR};\n    } else {\n        $root = \"$ENV{PROJECT_DIR}/$root\" unless $root eq \"\";\n    }\n\n    opendir(DIR, $root);\n\t\n\tmy @files = readdir(DIR);\n\tforeach (@files) {\n\t\tmy $filename = $_;\n\t\tnext unless -f \"$root/$filename\" && $filename =~ /\\.h$/s;\n\t\tmy @args = ( \"cp\", \"-fp\", \"$root/$filename\", \"$destination/\".(basename $filename) );\n\t\tsystem(@args) == 0 or die \"Copy failed: $?\";\n\t\tprint Horos_h \"#include <Horos/$filename>\\n\";\n\t}\n\t\n\tclosedir(DIR);\n}\n\nprint Horos_h \"\\n#endif\\n\";\nclose Horos_h;\n\nchdir \"$ENV{TARGET_BUILD_DIR}/$ENV{FULL_PRODUCT_NAME}\";\nsymlink \"Versions/Current/Headers\", \"Headers\";\n\nexit 0;";
 		};
 		ABF307FB1443330100BBC96A /* Copy odt2pdf script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -13704,14 +13625,6 @@
 				CE4441011165D1B70034BF18 /* jquant1.c in Sources */,
 				CE4441021165D1B70034BF18 /* jquant2.c in Sources */,
 				CE4441031165D1B70034BF18 /* jutils.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9966A1921AE099A400F2D81A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9966A19F1AE09B6F00F2D81A /* OsiriXHeaders.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -15975,11 +15888,6 @@
 			target = 59BDEC2C117C92B2007F1F2C /* Horos Launcher */;
 			targetProxy = 59BDEE6A117CB393007F1F2C /* PBXContainerItemProxy */;
 		};
-		9966A19D1AE09AFC00F2D81A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 9966A18E1AE099A400F2D81A /* OsiriX API (Legacy) */;
-			targetProxy = 9966A19C1AE09AFC00F2D81A /* PBXContainerItemProxy */;
-		};
 		9966A2E41AE0B8AF00F2D81A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9966A1B91AE0B7E000F2D81A /* OsiriX DCM Framework (Legacy) */;
@@ -16944,6 +16852,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -16965,7 +16874,7 @@
 					"-framework",
 					AppKit,
 				);
-				PRODUCT_NAME = HorosAPI;
+				PRODUCT_NAME = Horos;
 				SKIP_INSTALL = YES;
 			};
 			name = Deployment;
@@ -17299,66 +17208,6 @@
 			};
 			name = Development;
 		};
-		9966A1981AE099A400F2D81A /* Development */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				FRAMEWORK_VERSION = A;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_MODEL_TUNING = G5;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(SYSTEM_LIBRARY_DIR)/Frameworks/AppKit.framework/Headers/AppKit.h";
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				INFOPLIST_FILE = "OsiriXAPI-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-framework",
-					AppKit,
-				);
-				PRODUCT_NAME = OsiriXAPI;
-				SKIP_INSTALL = YES;
-			};
-			name = Development;
-		};
-		9966A1991AE099A400F2D81A /* Deployment */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				FRAMEWORK_VERSION = A;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_MODEL_TUNING = G5;
-				GCC_OPTIMIZATION_LEVEL = s;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(SYSTEM_LIBRARY_DIR)/Frameworks/AppKit.framework/Headers/AppKit.h";
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				INFOPLIST_FILE = "OsiriXAPI-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-framework",
-					AppKit,
-				);
-				PRODUCT_NAME = OsiriXAPI;
-				SKIP_INSTALL = YES;
-			};
-			name = Deployment;
-		};
 		9966A2DF1AE0B7E000F2D81A /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -17522,6 +17371,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -17543,7 +17393,7 @@
 					"-framework",
 					AppKit,
 				);
-				PRODUCT_NAME = HorosAPI;
+				PRODUCT_NAME = Horos;
 				SKIP_INSTALL = YES;
 			};
 			name = Development;
@@ -17704,15 +17554,6 @@
 			buildConfigurations = (
 				7E76BED9085757B70073649A /* Development */,
 				43E98D191A32BF6A001B9E51 /* Deployment */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Development;
-		};
-		9966A1971AE099A400F2D81A /* Build configuration list for PBXNativeTarget "OsiriX API (Legacy)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				9966A1981AE099A400F2D81A /* Development */,
-				9966A1991AE099A400F2D81A /* Deployment */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Development;


### PR DESCRIPTION
1) rename HorosAPI.framework to Horos.framework
2) build the Horos framework as universal binary (was 64 bits only)
3) include DCM headers in Horos.framework
4) delete the creation of the legacy OsiriXAPI.framework
5) change the way API frameworks are copied/linked inside Horos.app

The reason why OsiriXAPI.framework was named so is that, when we first created it, the name OsiriX.framework was already taken by the DCM framework. Since in Horos the DCM framework is now named HorosDCM.framework, we're now free to use Horos.framework for the API framework. Plugins' code will be much cleaner with #include <Horos/...> instead of #include <HorosAPI/...> or <OsiriXAPI/...>

It doesn't make much sense to compile the "old" OsiriXAPI.framework, as it's identical to the current Horos.framework. 

To support these plugin developers who have (mistakenly) hard-linked their plugins to OsiriXAPI.framework, or to OsiriX Headers.framework, or to HorosAPI.framework, we provide symbolic links to Horos.framework for these three. The Horos framework is actually empty, as it always has been (it only contains a dummy class).
