### PR TITLE
ITKSegmentation3D extractContour Updates intermediate filters.

### DIFF
--- a/ITKSegmentation3D.mm
+++ b/ITKSegmentation3D.mm
@@ -3,7 +3,7 @@
  
  Horos is free software: you can redistribute it and/or modify
  it under the terms of the GNU Lesser General Public License as published by
- the Free Software Foundation, Êversion 3 of the License.
+ the Free Software Foundation, ÃŠversion 3 of the License.
  
  Portions of the Horos Project were originally licensed under the GNU GPL license.
  However, all authors of that software have agreed to modify the license to the
@@ -11,24 +11,24 @@
  
  Horos is distributed in the hope that it will be useful, but
  WITHOUT ANY WARRANTY EXPRESS OR IMPLIED, INCLUDING ANY WARRANTY OF
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE OR USE. ÊSee the
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE OR USE. ÃŠSee the
  GNU Lesser General Public License for more details.
  
  You should have received a copy of the GNU Lesser General Public License
- along with Horos. ÊIf not, see http://www.gnu.org/licenses/lgpl.html
+ along with Horos. ÃŠIf not, see http://www.gnu.org/licenses/lgpl.html
  
  Prior versions of this file were published by the OsiriX team pursuant to
  the below notice and licensing protocol.
  ============================================================================
- Program: Ê OsiriX
- ÊCopyright (c) OsiriX Team
- ÊAll rights reserved.
- ÊDistributed under GNU - LGPL
- Ê
- ÊSee http://www.osirix-viewer.com/copyright.html for details.
- Ê Ê This software is distributed WITHOUT ANY WARRANTY; without even
- Ê Ê the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- Ê Ê PURPOSE.
+ Program: ÃŠ OsiriX
+ ÃŠCopyright (c) OsiriX Team
+ ÃŠAll rights reserved.
+ ÃŠDistributed under GNU - LGPL
+ ÃŠ
+ ÃŠSee http://www.osirix-viewer.com/copyright.html for details.
+ ÃŠ ÃŠ This software is distributed WITHOUT ANY WARRANTY; without even
+ ÃŠ ÃŠ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ ÃŠ ÃŠ PURPOSE.
  ============================================================================*/
 
 #import "options.h"
@@ -391,7 +391,7 @@ void ConnectPipelines(ITK_Exporter exporter, VTK_Importer* importer)
 	image2D->SetDataExtentToWholeExtent();
 	image2D->SetDataScalarTypeToUnsignedChar();
 	image2D->SetImportVoidPointer(map);
-    image2D->Update();
+	image2D->Update();
 	
 	vtkMarchingSquares*		isoContour = vtkMarchingSquares::New();
 	
@@ -406,12 +406,14 @@ void ConnectPipelines(ITK_Exporter exporter, VTK_Importer* importer)
 	if( largestRegion) filter->SetExtractionModeToLargestRegion();
 	else filter->SetExtractionModeToAllRegions();
 	filter->SetInputConnection( isoContour->GetOutputPort());
+	filter->Update();
 
 	vtkPolyDataConnectivityFilter	*filter2 = vtkPolyDataConnectivityFilter::New();
 	filter2->SetColorRegions( 1);
 	if( largestRegion) filter2->SetExtractionModeToLargestRegion();
 	else filter2->SetExtractionModeToAllRegions();
 	filter2->SetInputConnection( filter->GetOutputPort());
+	filter2->Update();
 
 	vtkPolyData *output = filter2->GetOutput();
 	//output->Update();


### PR DESCRIPTION
This method currently fails when attempting to extract the contour of a simple circular mask. Since VTK 6 doesn't provide Update() on vtkPolyData (line 418), we instead call update on filter and filter2 to correctly apply the filters before generating output.

Testing this with my input mask\* fixed the problem.

*(A 256x256 array of 0s, with a circular region of 1s in the center.)
