### PR TITLE
Preference panes: path bars changed to standard style

### DIFF
--- a/Preference Panes/OSICDPreferencePane/English.lproj/OSICDPreferencePanePref.xib
+++ b/Preference Panes/OSICDPreferencePane/English.lproj/OSICDPreferencePanePref.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="101100" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
@@ -181,10 +181,10 @@
                                         <binding destination="173" name="value" keyPath="values.JPEGinsteadJPEG2000" id="187"/>
                                     </connections>
                                 </button>
-                                <pathControl verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="202">
+                                <pathControl focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="202">
                                     <rect key="frame" x="235" y="12" width="318" height="20"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <pathCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" pathStyle="navigationBar" id="203">
+                                    <pathCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" focusRingType="none" alignment="left" id="203">
                                         <font key="font" metaFont="smallSystem"/>
                                         <url key="url" string="~Documents/FolderToBurn">
                                             <url key="baseURL" string="file://localhost/"/>

--- a/Preference Panes/OSIDatabasePreferencePane/English.lproj/OSIDatabasePreferencePanePref.xib
+++ b/Preference Panes/OSIDatabasePreferencePane/English.lproj/OSIDatabasePreferencePanePref.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="101100" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
@@ -166,9 +166,9 @@
                                     </textFieldCell>
                                 </textField>
                                 <pathControl focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="810">
-                                    <rect key="frame" x="348" y="108" width="213" height="20"/>
+                                    <rect key="frame" x="351" y="112" width="207" height="15"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <pathCell key="cell" controlSize="small" selectable="YES" enabled="NO" focusRingType="none" alignment="left" pathStyle="navigationBar" id="811">
+                                    <pathCell key="cell" controlSize="small" selectable="YES" enabled="NO" focusRingType="none" alignment="left" id="811">
                                         <font key="font" metaFont="smallSystem"/>
                                         <url key="url" string="file://localhost/Applications/"/>
                                     </pathCell>


### PR DESCRIPTION
Changed from deprecated navigation style to remove warning in Database and CD preference panes.  Also removed focus ring from path bar in CD to match Database.
