### PR TITLE
Clear warning with Xcode 7.3.1 (no change to settings)

### DIFF
--- a/Horos.xcodeproj/project.pbxproj
+++ b/Horos.xcodeproj/project.pbxproj
@@ -11041,7 +11041,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = NO;
 				LastTestingUpgradeCheck = 0730;
-				LastUpgradeCheck = 0640;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "The Horos Project";
 				TargetAttributes = {
 					59BDEC2C117C92B2007F1F2C = {


### PR DESCRIPTION
SDK maintained as is, specifying 10.11, rather than "latest (10.11)"
