### PR TITLE
fix loading plugins with relative (symbolic) links

### DIFF
--- a/PluginManager.m
+++ b/PluginManager.m
@@ -856,8 +856,12 @@ BOOL gPluginsAlertAlreadyDisplayed = NO;
                 
                 NSString* name;
                 while (name = [e nextObject])
-                    if ([donotloadnames containsObject:[name stringByDeletingPathExtension]] == NO)
-                        [pathsOfPluginsToLoad addObject:[NSFileManager.defaultManager destinationOfAliasOrSymlinkAtPath:[path stringByAppendingPathComponent: name]]];
+                    if ([donotloadnames containsObject:[name stringByDeletingPathExtension]] == NO) {
+                        NSString *ppath = [path stringByAppendingPathComponent:name];
+                        NSString *rpath = [NSFileManager.defaultManager destinationOfAliasOrSymlinkAtPath:ppath];
+                        NSURL *url = [NSURL fileURLWithPath:rpath relativeToURL:[NSURL fileURLWithPath:ppath isDirectory:NO]];
+                        [pathsOfPluginsToLoad addObject:url.path];
+                    }
             } @catch (NSException* e) {
                 N2LogExceptionWithStackTrace(e);
             }


### PR DESCRIPTION
Horos currently fails loading plugin that use relative symbolic links:

```
default	11:50:48.819616 +0100	Horos	|||||||||||||||||| Plugins loading START ||||||||||||||||||
default	11:50:48.823043 +0100	Horos	**** Bundle opening failed for plugin: ../path/to/Sample.horosplugin
default	11:50:48.823352 +0100	Horos	|||||||||||||||||| Plugins loading END ||||||||||||||||||
```

This patch resolves this problem.