### PR TITLE
[HOR-22] Folders are required before deploying SQL files

### DIFF
--- a/Nitrogen/Sources/N2ManagedDatabase.mm
+++ b/Nitrogen/Sources/N2ManagedDatabase.mm
@@ -307,7 +307,10 @@ static int gTotalN2ManagedObjectContext = 0;
                 
                 BOOL isNewFile = ![NSFileManager.defaultManager fileExistsAtPath:sqlFilePath];
                 if (isNewFile)
+                {
+                    [[NSFileManager defaultManager] confirmDirectoryAtPath:[sqlFilePath stringByDeletingLastPathComponent]];
                     moc.persistentStoreCoordinator = nil;
+                }
                 
                 if (!moc.persistentStoreCoordinator)
                 {


### PR DESCRIPTION
Fixed database initialization (SQL file deploy) when user is doing a clean install of Horos