### PR TITLE
Loupe magnification can be reduced with -/_ key on main keyboard

### DIFF
--- a/Horos/Sources/DCMView.m
+++ b/Horos/Sources/DCMView.m
@@ -2750,7 +2750,7 @@ NSInteger studyCompare(ViewerController *v1, ViewerController *v2, void *context
         
         if(lensTexture)
         {
-            if(c == 45) //  '-'
+            if(c == 45 || c == 95) //  '-' (numeric keypad) or '_' (standard keyboard)
             {
                 if(lensZoomFactor < 4.0f) {
                     lensZoomFactor += 0.2;


### PR DESCRIPTION
The loupe zoom level works with the numeric keyboard +/- keys.  It also works with the main keyboard's + key (with the shift key down), but not its - which becomes _ with the shift key.  This PR allows the _ key.  This may not help on some keyboard layouts though.