### PR TITLE
Fixes #332. Problems were related to images having 16bit pixel depth …

### DIFF
--- a/DCM Framework/DCMPixelDataAttribute.mm
+++ b/DCM Framework/DCMPixelDataAttribute.mm
@@ -2769,9 +2769,7 @@ void info_callback(const char *msg, void *a) {
                         {
                             for( x = 0; x < width; x++)
                             {
-                                if (clutDepthR != 16 || clutDepthG != 16 || clutDepthB != 16)
-                                    pixelR = pixelG = pixelB = bufPtr[y*width + x];
-                                else pixelR = pixelG = pixelB = bufPtr16[y*width + x];
+                                pixelR = pixelG = pixelB = bufPtr[y*width + x];
                                 
                                 if( pixelR > clutEntryR) {	pixelR = clutEntryR-1;}
                                 if( pixelG > clutEntryG) {	pixelG = clutEntryG-1;}
@@ -2854,7 +2852,7 @@ void info_callback(const char *msg, void *a) {
     if (shortBlue != nil)
         free(shortBlue);
     //NSLog(@"end palette conversion end length: %d", [rgbData length]);
-    _pixelDepth = 8;
+
     return rgbData;
     
 }
@@ -3232,8 +3230,6 @@ void info_callback(const char *msg, void *a) {
         [_dcmObject setAttributeValues:[NSMutableArray arrayWithObject:[NSNumber numberWithInt:7]] forName:@"HighBit"];
         
         _samplesPerPixel = [[[_dcmObject attributeForTag:[DCMAttributeTag tagWithName:@"SamplesperPixel"]] value] intValue];
-        
-        _pixelDepth = 8;
     }
     
 }


### PR DESCRIPTION
…and color palette.
- Reverts a change made at 
https://github.com/horosproject/horos/commit/bf57cdd6970d14f1511e4449671d7ae1763cb1c7 that was causing the crash;
-  Removes hard-coded `_pixelDepth = 8;` at two places in DCMPixelAttributeData. Looks like someone misinterpreted `_pixelDepth` as the palette pixel depth, when it is in fact the pixel depth of the image. This was causing images with 16bit pixel depth being rendered incorrectly, as was the case of some of the series mentioned in the issue.