### PR TITLE
Save 4D Player frame rate to defaults

### DIFF
--- a/Horos/Sources/DefaultsOsiriX.m
+++ b/Horos/Sources/DefaultsOsiriX.m
@@ -1108,6 +1108,7 @@ static NSHost *currentHost = nil;
 	[defaultValues setObject:@"0" forKey:@"notificationsEmails"];
 	[defaultValues setObject:@"0" forKey:@"validateFilesBeforeImporting"];
 	[defaultValues setObject:@"10" forKey:@"defaultFrameRate"];
+    [defaultValues setObject:@"10" forKey:@"defaultMovieRate"];
 	[defaultValues setObject:@"10" forKey:@"quicktimeExportRateValue"];
     [defaultValues setObject:AVVideoCodecJPEG forKey:@"selectedMenuAVFoundationExport"];
 	[defaultValues setObject:@"0" forKey:@"32bitDICOMAreAlwaysIntegers"];

--- a/Horos/Sources/ViewerController.h
+++ b/Horos/Sources/ViewerController.h
@@ -383,7 +383,9 @@ enum
 @property(readonly) NSTimer	*timer;
 @property(readonly) NSButton *keyImageCheck;
 @property(readonly) NSSlider *speedSlider;
+@property(readonly) NSSlider *movieRateSlider;
 @property(readonly) NSTextField *speedText;
+@property(readonly) NSTextField *movieTextSlide;
 //@property(readonly) NSSplitView *leftSplitView;
 @property(retain) NSString *windowsStateName;
 /** Accessors for plugins using blending window */
@@ -684,6 +686,7 @@ enum
 - (void) PlayStop:(id) sender;
 - (short) getNumberOfImages;
 - (float) frameRate;
+- (float) movieRate;
 - (void) adjustSlider;
 - (IBAction) sliderFusionAction:(id) sender;
 - (IBAction) popFusionAction:(id) sender;

--- a/Horos/Sources/ViewerController.m
+++ b/Horos/Sources/ViewerController.m
@@ -8374,6 +8374,12 @@ static int avoidReentryRefreshDatabase = 0;
                     [movieRateSlider setEnabled: NO];
                     [moviePosSlider setEnabled: NO];
                     [moviePlayStop setEnabled:NO];
+
+                    if( [[NSUserDefaults standardUserDefaults] floatForKey: @"defaultMovieRate"])
+                    {
+                        [movieRateSlider setFloatValue: [[NSUserDefaults standardUserDefaults] floatForKey: @"defaultMovieRate"]];
+                        [movieTextSlide setStringValue:[NSString stringWithFormat:NSLocalizedString(@"%0.0f im/s", @"im/s = images per second"), (float) [self movieRate]]];
+                    }
                     
                     [speedText setStringValue:[NSString stringWithFormat:NSLocalizedString(@"%0.1f im/s",  @"im/s = images per second"), (float) [self frameRate]*direction]];
                     
@@ -17442,6 +17448,11 @@ static float oldsetww, oldsetwl;
     return [speedSlider floatValue];
 }
 
+- (float) movieRate
+{
+    return [movieRateSlider floatValue];
+}
+
 - (void) speedSliderAction:(id) sender
 {
     [speedText setStringValue:[NSString stringWithFormat: NSLocalizedString( @"%0.1f im/s", @"im/s = images per second"), (float) [self frameRate] * direction]];
@@ -17468,7 +17479,28 @@ static float oldsetww, oldsetwl;
 
 - (void) movieRateSliderAction:(id) sender
 {
-    [movieTextSlide setStringValue:[NSString stringWithFormat: NSLocalizedString( @"%0.0f im/s", @"im/s = images per second"), (float) [movieRateSlider floatValue]]];
+    float movieRate = (float) [self movieRate];
+
+    [movieTextSlide setStringValue:[NSString stringWithFormat: NSLocalizedString( @"%0.0f im/s", @"im/s = images per second"), movieRate]];
+
+    if( [[self window] isKeyWindow])
+    {
+        for( ViewerController *v in [ViewerController getDisplayed2DViewers])
+        {
+            if( v != self)
+            {
+                if( [v movieRate] == [[NSUserDefaults standardUserDefaults] floatForKey: @"defaultMovieRate"])
+                {
+                    if( v.movieRateSlider.floatValue != movieRate)
+                    {
+                        v.movieRateSlider.floatValue = movieRate;
+                        v.movieTextSlide.stringValue = [NSString stringWithFormat: NSLocalizedString( @"%0.0f im/s", @"im/s = images per second"), movieRate];
+                    }
+                }
+            }
+        }
+        [[NSUserDefaults standardUserDefaults] setFloat: movieRate forKey: @"defaultMovieRate"];
+    }
 }
 
 -(NSSlider*) moviePosSlider


### PR DESCRIPTION
In Horos 3.1.2, ever time the 4D Viewer tool is used to view a series with multiple time points, the 4D Player defaults to 10 frames/second. If the user modifies this frame rate, closes the series and opens a new series it will again default to 10 frames/second.

It is desirable that if the user changes the 4D Player frame rate that the value should persist between series, and persist between restarts of Horos. This is the way that the cine viewer frame rate works: it is saved to defaults whenever it is changed.

This PR updates the 4D Player frame rate to be persistently saved in the same way that the cine viewer's frame rate is.