### PR TITLE
Polygon ROIs on Grow Region segmentation alive again

### DIFF
--- a/Horos/Sources/ITKSegmentation3D.mm
+++ b/Horos/Sources/ITKSegmentation3D.mm
@@ -55,8 +55,6 @@ The Horos Project was based originally upon the OsiriX Project which at the time
 #include <itkCastImageFilter.h>
 #include <itkBinaryMaskToNarrowBandPointSetFilter.h>
 //#include <itkBinaryMask3DMeshSource.h>
-#include <itkVTKImageExport.h>
-#include <itkVTKImageExportBase.h>
 #include <itkGrayscaleDilateImageFilter.h>
 #include <itkBinaryBallStructuringElement.h>
 
@@ -88,44 +86,6 @@ The Horos Project was based originally upon the OsiriX Project which at the time
 #import "OSIVoxel.h"
 #import "AppController.h"
 #import "ITKSegmentation3D.h"
-
-/**
- * This function will connect the given itk::VTKImageExport filter to
- * the given vtkImageImport filter.
- */
-template <typename ITK_Exporter, typename VTK_Importer>
-void ConnectPipelines(ITK_Exporter exporter, VTK_Importer* importer)
-{
-  importer->SetUpdateInformationCallback(exporter->GetUpdateInformationCallback());
-  importer->SetPipelineModifiedCallback(exporter->GetPipelineModifiedCallback());
-  importer->SetWholeExtentCallback(exporter->GetWholeExtentCallback());
-  importer->SetSpacingCallback(exporter->GetSpacingCallback());
-  importer->SetOriginCallback(exporter->GetOriginCallback());
-  importer->SetScalarTypeCallback(exporter->GetScalarTypeCallback());
-  importer->SetNumberOfComponentsCallback(exporter->GetNumberOfComponentsCallback());
-  importer->SetPropagateUpdateExtentCallback(exporter->GetPropagateUpdateExtentCallback());
-  importer->SetUpdateDataCallback(exporter->GetUpdateDataCallback());
-  importer->SetDataExtentCallback(exporter->GetDataExtentCallback());
-  importer->SetBufferPointerCallback(exporter->GetBufferPointerCallback());
-  importer->SetCallbackUserData(exporter->GetCallbackUserData());
-}
-
-//template <typename VTK_Exporter, typename ITK_Importer>
-//void ConnectPipelines(VTK_Exporter* exporter, ITK_Importer importer)
-//{
-//  importer->SetUpdateInformationCallback(exporter->GetUpdateInformationCallback());
-//  importer->SetPipelineModifiedCallback(exporter->GetPipelineModifiedCallback());
-//  importer->SetWholeExtentCallback(exporter->GetWholeExtentCallback());
-//  importer->SetSpacingCallback(exporter->GetSpacingCallback());
-//  importer->SetOriginCallback(exporter->GetOriginCallback());
-//  importer->SetScalarTypeCallback(exporter->GetScalarTypeCallback());
-//  importer->SetNumberOfComponentsCallback(exporter->GetNumberOfComponentsCallback());
-//  importer->SetPropagateUpdateExtentCallback(exporter->GetPropagateUpdateExtentCallback());
-//  importer->SetUpdateDataCallback(exporter->GetUpdateDataCallback());
-//  importer->SetDataExtentCallback(exporter->GetDataExtentCallback());
-//  importer->SetBufferPointerCallback(exporter->GetBufferPointerCallback());
-//  importer->SetCallbackUserData(exporter->GetCallbackUserData());
-//}
 
 @implementation ITKSegmentation3D
 


### PR DESCRIPTION
Polygon ROIs alive again in Region Grow segmentation - fixed via ITK/VTK corrections.
Correct usage of Update() calls; ITK/VTK pipelines' connection via itk::VTKImageExport removed (failing and wasn't really used).