### PR TITLE
Remote database fix

### DIFF
--- a/Horos/Sources/BrowserController+Sources.m
+++ b/Horos/Sources/BrowserController+Sources.m
@@ -305,7 +305,7 @@ enum {
     NSArray* io = [NSMutableArray arrayWithObjects: @"Local", path, name, nil];
     
     NSThread* thread = [[[NSThread alloc] initWithTarget:self selector:@selector(setDatabaseThread:) object:io] autorelease];
-    thread.name = NSLocalizedString(@"Loading OsiriX database...", nil);
+    thread.name = NSLocalizedString(@"Loading database...", nil);
     thread.supportsCancel = YES;
     thread.status = NSLocalizedString(@"Reading data...", nil);
     

--- a/Horos/Sources/BrowserController.m
+++ b/Horos/Sources/BrowserController.m
@@ -2945,7 +2945,7 @@ static NSConditionLock *threadLock = nil;
         DataNodeIdentifier* bs = [self sourceIdentifierAtRow: [_sourcesTableView selectedRow]];
         
         if( bs)
-            description = [description stringByAppendingFormat:NSLocalizedString(@"%@: %@ / ", nil), [_database isLocal] ? NSLocalizedString( @"Local Database: ", nil) : NSLocalizedString( @"Distant Database: ", nil), [bs description]];
+            description = [description stringByAppendingFormat:NSLocalizedString(@"%@: %@ / ", nil), [_database isLocal] ? NSLocalizedString( @"Local Database", nil) : NSLocalizedString( @"Remote Database", nil), [bs description]];
     }
     
     // ********************
@@ -14410,7 +14410,7 @@ static NSArray*	openSubSeriesArray = nil;
             N2LogExceptionWithStackTrace(ne);
             [@"" writeToFile:_database.loadingFilePath atomically:NO encoding:NSUTF8StringEncoding error:NULL];
             
-            NSString *message = [NSString stringWithFormat: NSLocalizedString(@"A problem occured during start-up of OsiriX:\r\r%@\r\r%@",nil), [ne description], [AppController printStackTrace: ne]];
+            NSString *message = [NSString stringWithFormat: NSLocalizedString(@"A problem occured during start-up of Horos:\r\r%@\r\r%@",nil), [ne description], [AppController printStackTrace: ne]];
             
             NSRunCriticalAlertPanel(NSLocalizedString(@"Error",nil), @"%@", NSLocalizedString( @"OK",nil), nil, nil, message);
             

--- a/Horos/Sources/BrowserController.m
+++ b/Horos/Sources/BrowserController.m
@@ -4970,7 +4970,7 @@ static NSConditionLock *threadLock = nil;
     }
 }
 
-- (void)outlineViewSelectionDidChange: (NSNotification *)aNotification
+- (void)outlineViewSelectionDidChange:(NSNotification *)aNotification
 {
     if( [NSThread isMainThread] == NO)
         N2LogStackTrace( @"***** We must be on MAIN thread");

--- a/Horos/Sources/CPRMPRDCMView.m
+++ b/Horos/Sources/CPRMPRDCMView.m
@@ -568,7 +568,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
             [vrView renderBlendedVolume];
             
             float *blendedImagePtr = nil;
-            DCMPix *bPix = [blendingView curDCM];
+            DCMPix *bPix = blendingView.curDCM;
             
             if( moveCenter)
             {
@@ -896,10 +896,10 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
 			
 			glPointSize( 10 * self.window.backingScaleFactor);
 			glBegin( GL_POINTS);
-			sc[0] = sc[ 0] / curDCM.pixelSpacingX;
-			sc[1] = sc[ 1] / curDCM.pixelSpacingY;
-			sc[0] -= curDCM.pwidth * 0.5f;
-			sc[1] -= curDCM.pheight * 0.5f;
+			sc[0] = sc[ 0] / self.curDCM.pixelSpacingX;
+			sc[1] = sc[ 1] / self.curDCM.pixelSpacingY;
+			sc[0] -= self.curDCM.pwidth * 0.5f;
+			sc[1] -= self.curDCM.pheight * 0.5f;
 			glVertex2f( scaleValue*sc[ 0], scaleValue*sc[ 1]);
 			glEnd();
             
@@ -915,10 +915,10 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
 			
 			glPointSize( 10 * self.window.backingScaleFactor);
 			glBegin( GL_POINTS);
-			sc[0] = sc[ 0] / curDCM.pixelSpacingX;
-			sc[1] = sc[ 1] / curDCM.pixelSpacingY;
-			sc[0] -= curDCM.pwidth * 0.5f;
-			sc[1] -= curDCM.pheight * 0.5f;
+			sc[0] = sc[ 0] / self.curDCM.pixelSpacingX;
+			sc[1] = sc[ 1] / self.curDCM.pixelSpacingY;
+			sc[0] -= self.curDCM.pwidth * 0.5f;
+			sc[1] -= self.curDCM.pheight * 0.5f;
 			glVertex2f( scaleValue*sc[ 0], scaleValue*sc[ 1]);
 			glEnd();
             
@@ -934,10 +934,10 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
 			
 			glPointSize( 10 * self.window.backingScaleFactor);
 			glBegin( GL_POINTS);
-			sc[0] = sc[ 0] / curDCM.pixelSpacingX;
-			sc[1] = sc[ 1] / curDCM.pixelSpacingY;
-			sc[0] -= curDCM.pwidth * 0.5f;
-			sc[1] -= curDCM.pheight * 0.5f;
+			sc[0] = sc[ 0] / self.curDCM.pixelSpacingX;
+			sc[1] = sc[ 1] / self.curDCM.pixelSpacingY;
+			sc[0] -= self.curDCM.pwidth * 0.5f;
+			sc[1] -= self.curDCM.pheight * 0.5f;
 			glVertex2f( scaleValue*sc[ 0], scaleValue*sc[ 1]);
 			glEnd();
 		}
@@ -1394,7 +1394,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
 	if( LOD == 0)
 		return 0;
 	
-	if( curDCM.pixelSpacingX == 0)
+	if( self.curDCM.pixelSpacingX == 0)
 		return 0;
 	
 	// Intersection of the lines
@@ -1404,10 +1404,10 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
 	{
 		mouseLocation = [self ConvertFromNSView2GL: mouseLocation];
 		
-		mouseLocation.x *= curDCM.pixelSpacingX;
-		mouseLocation.y *= curDCM.pixelSpacingY;
+		mouseLocation.x *= self.curDCM.pixelSpacingX;
+		mouseLocation.y *= self.curDCM.pixelSpacingY;
 		
-		float f = curDCM.pixelSpacingX / LOD * self.window.backingScaleFactor;
+		float f = self.curDCM.pixelSpacingX / LOD * self.window.backingScaleFactor;
 		
 		if( mouseLocation.x > r.x - BS * f && mouseLocation.x < r.x + BS* f && mouseLocation.y > r.y - BS* f && mouseLocation.y < r.y + BS* f)
 		{
@@ -1422,7 +1422,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
                 NSPoint a1 = NSMakePoint( crossLinesA[ 0][ 0], crossLinesA[ 0][ 1]);
                 NSPoint a2 = NSMakePoint( crossLinesA[ 1][ 0], crossLinesA[ 1][ 1]);
                 [DCMView DistancePointLine:mouseLocation :a1 :a2 :&distance1];
-                distance1 /= curDCM.pixelSpacingX;
+                distance1 /= self.curDCM.pixelSpacingX;
             }
             
             if( crossLinesB[ 0][ 0] != HUGE_VALF)
@@ -1431,7 +1431,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
                 NSPoint b2 = NSMakePoint( crossLinesB[ 1][ 0], crossLinesB[ 1][ 1]);			
 			
                 [DCMView DistancePointLine:mouseLocation :b1 :b2 :&distance2];
-                distance2 /= curDCM.pixelSpacingX;
+                distance2 /= self.curDCM.pixelSpacingX;
 			}
             
 			if( distance1 * scaleValue < 10*self.window.backingScaleFactor || distance2 * scaleValue < 10*self.window.backingScaleFactor)
@@ -1690,7 +1690,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
 			rotateLines = YES;
 			
 			NSPoint mouseLocation = [self ConvertFromNSView2GL: [self convertPoint: [theEvent locationInWindow] fromView: nil]];
-			mouseLocation.x *= curDCM.pixelSpacingX;	mouseLocation.y *= curDCM.pixelSpacingY;
+			mouseLocation.x *= self.curDCM.pixelSpacingX;	mouseLocation.y *= self.curDCM.pixelSpacingY;
 			rotateLinesStartAngle = [self angleBetween: mouseLocation center: [self centerLines]] - angleMPR;
 			
 			[self mouseDragged: theEvent];
@@ -2029,7 +2029,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
 		windowController.lowLOD = YES;
 		
 		NSPoint mouseLocation = [self ConvertFromNSView2GL: [self convertPoint: [theEvent locationInWindow] fromView: nil]];
-		mouseLocation.x *= curDCM.pixelSpacingX;	mouseLocation.y *= curDCM.pixelSpacingY;
+		mouseLocation.x *= self.curDCM.pixelSpacingX;	mouseLocation.y *= self.curDCM.pixelSpacingY;
 		angleMPR = [self angleBetween: mouseLocation center: [self centerLines]];
 		
 		angleMPR -= rotateLinesStartAngle;
@@ -2437,7 +2437,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
     if( cgl_ctx == nil)
         return;
     
-	if( isnan( curDCM.pixelSpacingX) || isnan( curDCM.pixelSpacingY) || curDCM.pixelSpacingX <= 0 || curDCM.pixelSpacingY <= 0 || curDCM.pixelSpacingX > 1000 || curDCM.pixelSpacingY > 1000)
+	if( isnan( self.curDCM.pixelSpacingX) || isnan( self.curDCM.pixelSpacingY) || self.curDCM.pixelSpacingX <= 0 || self.curDCM.pixelSpacingY <= 0 || self.curDCM.pixelSpacingX > 1000 || self.curDCM.pixelSpacingY > 1000)
 	{
 		return;
 	}
@@ -2740,7 +2740,7 @@ static CGFloat CPRMPRDCMViewCurveMouseTrackingDistance = 20.0;
     
     pixToDicomTransform = [self pixToDicomTransform];
     
-    plane.point = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth/2.0, (CGFloat)curDCM.pheight/2.0, 0.0), pixToDicomTransform);
+    plane.point = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth/2.0, (CGFloat)self.curDCM.pheight/2.0, 0.0), pixToDicomTransform);
     plane.normal = N3VectorNormalize(N3VectorApplyTransformToDirectionalVector(N3VectorMake(0.0, 0.0, 1.0), pixToDicomTransform));
     
 	if (N3PlaneIsValid(plane)) {

--- a/Horos/Sources/CPRStraightenedView.m
+++ b/Horos/Sources/CPRStraightenedView.m
@@ -347,7 +347,7 @@ extern int splitPosition[ 3];
     if (mode != _clippingRangeMode) {
         _clippingRangeMode = mode;
         
-        if (curDCM) {
+        if (self.curDCM) {
             [self setFusion:[[self class] _fusionModeForCPRViewClippingRangeMode:_clippingRangeMode] :self.curvedVolumeData.pixelsDeep];
         }
         [self _setNeedsNewRequest];
@@ -381,7 +381,7 @@ extern int splitPosition[ 3];
 	{
 		float length = [_curvedPath.bezierPath length];
 	
-		NSMutableArray *topLeft = [curDCM.annotationsDictionary objectForKey: @"TopLeft"];
+		NSMutableArray *topLeft = [self.curDCM.annotationsDictionary objectForKey: @"TopLeft"];
 		
 		length *= 0.1; // We want cm
 		
@@ -445,7 +445,7 @@ extern int splitPosition[ 3];
 	glPointSize( 12 * self.window.backingScaleFactor);
 	
     pixToSubDrawRectTransform = [self pixToSubDrawRectTransform];
-    pixelsPerMm = (CGFloat)curDCM.pwidth/[_curvedPath.bezierPath length];
+    pixelsPerMm = (CGFloat)self.curDCM.pwidth/[_curvedPath.bezierPath length];
 
     if (_displayCrossLines) {
         for (planeName in _planes) {
@@ -465,8 +465,8 @@ extern int splitPosition[ 3];
         }
     }
 	
-	lineStart = N3VectorMake(0, (CGFloat)curDCM.pheight/2.0, 0);
-    lineEnd = N3VectorMake(curDCM.pwidth, (CGFloat)curDCM.pheight/2.0, 0);
+	lineStart = N3VectorMake(0, (CGFloat)self.curDCM.pheight/2.0, 0);
+    lineEnd = N3VectorMake(self.curDCM.pwidth, (CGFloat)self.curDCM.pheight/2.0, 0);
     
     lineStart = N3VectorApplyTransform(lineStart, pixToSubDrawRectTransform);
     lineEnd = N3VectorApplyTransform(lineEnd, pixToSubDrawRectTransform);
@@ -482,7 +482,7 @@ extern int splitPosition[ 3];
     
     if ( [[self windowController] displayMousePosition] == YES && _displayInfo.mouseCursorHidden == NO)
 	{
-        cursorVector = N3VectorMake(curDCM.pwidth * _displayInfo.mouseCursorPosition, (CGFloat)curDCM.pheight/2.0, 0);
+        cursorVector = N3VectorMake(self.curDCM.pwidth * _displayInfo.mouseCursorPosition, (CGFloat)self.curDCM.pheight/2.0, 0);
         cursorVector = N3VectorApplyTransform(cursorVector, pixToSubDrawRectTransform);
         
         glEnable(GL_POINT_SMOOTH);
@@ -497,8 +497,8 @@ extern int splitPosition[ 3];
 	{
         glColor4d(1.0, 0.0, 0.0, 1.0);
         draggedPosition = _displayInfo.draggedPosition;
-        lineStart = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*draggedPosition, 0, 0), pixToSubDrawRectTransform);
-        lineEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*draggedPosition, curDCM.pheight, 0), pixToSubDrawRectTransform);
+        lineStart = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*draggedPosition, 0, 0), pixToSubDrawRectTransform);
+        lineEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*draggedPosition, self.curDCM.pheight, 0), pixToSubDrawRectTransform);
         glLineWidth(2.0 * self.window.backingScaleFactor);
         glBegin(GL_LINE_STRIP);
         glVertex2f(lineStart.x, lineStart.y);
@@ -533,8 +533,8 @@ extern int splitPosition[ 3];
 		for( int i = 0; i < noOfFrames; i++)
 		{
 			transverseSectionPosition = (startingDistance + ((float) i * exportTransverseSliceInterval)) / (float) _curvedPath.bezierPath.length;
-			lineStart = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*transverseSectionPosition, curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
-			lineEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*transverseSectionPosition, curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
+			lineStart = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*transverseSectionPosition, self.curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
+			lineEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*transverseSectionPosition, self.curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
 			glLineWidth(2.0 * self.window.backingScaleFactor);
 			glBegin(GL_LINE_STRIP);
 			glVertex2f(lineStart.x, lineStart.y);
@@ -553,8 +553,8 @@ extern int splitPosition[ 3];
 		// draw the transverse section lines
 		glColor4d(1.0, 1.0, 0.0, 1.0);
 		transverseSectionPosition = _curvedPath.transverseSectionPosition;
-		lineBStart = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*transverseSectionPosition, curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
-		lineBEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*transverseSectionPosition, curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
+		lineBStart = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*transverseSectionPosition, self.curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
+		lineBEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*transverseSectionPosition, self.curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
 		glLineWidth(2.0 * self.window.backingScaleFactor);
 		glBegin(GL_LINE_STRIP);
 		glVertex2f(lineBStart.x, lineBStart.y);
@@ -562,8 +562,8 @@ extern int splitPosition[ 3];
 		glEnd();
 				
 		leftTransverseSectionPosition = _curvedPath.leftTransverseSectionPosition;
-		lineAStart = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*leftTransverseSectionPosition, curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
-		lineAEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*leftTransverseSectionPosition, curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
+		lineAStart = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*leftTransverseSectionPosition, self.curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
+		lineAEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*leftTransverseSectionPosition, self.curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
 		glLineWidth(1.0 * self.window.backingScaleFactor);
 		glBegin(GL_LINE_STRIP);
 		glVertex2f(lineAStart.x, lineAStart.y);
@@ -571,8 +571,8 @@ extern int splitPosition[ 3];
 		glEnd();
 		
 		rightTransverseSectionPosition = _curvedPath.rightTransverseSectionPosition;
-		lineCStart = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*rightTransverseSectionPosition, curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
-		lineCEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*rightTransverseSectionPosition, curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
+		lineCStart = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*rightTransverseSectionPosition, self.curDCM.pheight/2. - transverseWidth/2., 0), pixToSubDrawRectTransform);
+		lineCEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*rightTransverseSectionPosition, self.curDCM.pheight/2. + transverseWidth/2., 0), pixToSubDrawRectTransform);
 		glBegin(GL_LINE_STRIP);
 		glVertex2f(lineCStart.x, lineCStart.y);
 		glVertex2f(lineCEnd.x, lineCEnd.y);
@@ -688,7 +688,7 @@ extern int splitPosition[ 3];
                     break;
             }
             
-            cursorVector = N3VectorMake((CGFloat)curDCM.pwidth*relativePosition, ((CGFloat)curDCM.pheight/2.0)+(_displayInfo.mouseTransverseSectionDistance*pixelsPerMm), 0);
+            cursorVector = N3VectorMake((CGFloat)self.curDCM.pwidth*relativePosition, ((CGFloat)self.curDCM.pheight/2.0)+(_displayInfo.mouseTransverseSectionDistance*pixelsPerMm), 0);
             cursorVector = N3VectorApplyTransform(cursorVector, pixToSubDrawRectTransform);
             
             glColor4d(1.0, 1.0, 0.0, 1.0);
@@ -705,7 +705,7 @@ extern int splitPosition[ 3];
         for (i = 0; i < [_curvedPath.nodes count]; i++)
 		{
             relativePosition = [_curvedPath relativePositionForNodeAtIndex:i];
-            cursorVector = N3VectorMake(curDCM.pwidth * relativePosition, (CGFloat)curDCM.pheight/2.0, 0);
+            cursorVector = N3VectorMake(self.curDCM.pwidth * relativePosition, (CGFloat)self.curDCM.pheight/2.0, 0);
             cursorVector = N3VectorApplyTransform(cursorVector, pixToSubDrawRectTransform);
             
             if (_displayInfo.hoverNodeHidden == NO && _displayInfo.hoverNodeIndex == i)
@@ -801,9 +801,9 @@ extern int splitPosition[ 3];
 		
 		pixVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(viewPoint), [self viewToPixTransform]);
 		
-		if (NSPointInRect(viewPoint, self.bounds) && curDCM.pwidth > 0) {
+		if (NSPointInRect(viewPoint, self.bounds) && self.curDCM.pwidth > 0) {
 			[self _sendWillEditDisplayInfo];
-			_displayInfo.mouseCursorPosition = MIN(MAX(pixVector.x/(CGFloat)curDCM.pwidth, 0.0), 1.0);
+			_displayInfo.mouseCursorPosition = MIN(MAX(pixVector.x/(CGFloat)self.curDCM.pwidth, 0.0), 1.0);
 			[self setNeedsDisplay:YES];
 		
 			[self _updateMousePlanePointsForViewPoint:viewPoint];  // this will modify _mousePlanePointsInPix and _displayInfo
@@ -812,26 +812,26 @@ extern int splitPosition[ 3];
             _displayInfo.mouseTransverseSection = CPRTransverseViewNoneSectionType;
             _displayInfo.mouseTransverseSectionDistance = 0.0;
             if (_displayTransverseLines) {
-                distance = ABS(pixVector.x - _curvedPath.leftTransverseSectionPosition*(CGFloat)curDCM.pwidth);
+                distance = ABS(pixVector.x - _curvedPath.leftTransverseSectionPosition*(CGFloat)self.curDCM.pwidth);
                 minDistance = distance;
                 if (distance < 20.0) {
                     _displayInfo.mouseTransverseSection = CPRTransverseViewLeftSectionType;
-                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth);
+                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)self.curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth);
                 }
-                distance = ABS(pixVector.x - _curvedPath.rightTransverseSectionPosition*(CGFloat)curDCM.pwidth);
+                distance = ABS(pixVector.x - _curvedPath.rightTransverseSectionPosition*(CGFloat)self.curDCM.pwidth);
                 if (distance < 20.0 && distance < minDistance) {
                     _displayInfo.mouseTransverseSection = CPRTransverseViewRightSectionType;
-                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth);
+                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)self.curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth);
                     minDistance = distance;
                 }
-                distance = ABS(pixVector.x - _curvedPath.transverseSectionPosition*(CGFloat)curDCM.pwidth);
+                distance = ABS(pixVector.x - _curvedPath.transverseSectionPosition*(CGFloat)self.curDCM.pwidth);
                 if (distance < 20.0 && distance < minDistance) {
                     _displayInfo.mouseTransverseSection = CPRTransverseViewCenterSectionType;
-                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth);
+                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)self.curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth);
                 }
             }            
             
-			line = N3LineMake(N3VectorMake(0, (CGFloat)curDCM.pheight / 2.0, 0), N3VectorMake(1, 0, 0));
+			line = N3LineMake(N3VectorMake(0, (CGFloat)self.curDCM.pheight / 2.0, 0), N3VectorMake(1, 0, 0));
 			line = N3LineApplyTransform(line, N3AffineTransformInvert([self viewToPixTransform]));
 			
 			if (N3VectorDistanceToLine(N3VectorMakeFromNSPoint(viewPoint), line) < 20.0) {
@@ -847,7 +847,7 @@ extern int splitPosition[ 3];
 					relativePosition = [_curvedPath relativePositionForNodeAtIndex:i];
 					
 					if (N3VectorDistance(N3VectorMakeFromNSPoint(viewPoint),
-										  N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*relativePosition, (CGFloat)curDCM.pheight/2.0, 0), N3AffineTransformInvert([self viewToPixTransform]))) < 10.0) {
+										  N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*relativePosition, (CGFloat)self.curDCM.pheight/2.0, 0), N3AffineTransformInvert([self viewToPixTransform]))) < 10.0) {
 						overNode = YES;
 						hoverNodeIndex = i;
 						break;
@@ -876,7 +876,7 @@ extern int splitPosition[ 3];
 			exportTransverseSliceInterval = [[self windowController] exportTransverseSliceInterval];
 		
 		
-		if( curDCM.pwidth != 0 && exportTransverseSliceInterval == 0 && _displayTransverseLines && ((ABS((pixVector.x/curDCM.pwidth) - _curvedPath.transverseSectionPosition)*curDCM.pwidth < 5.0) || (ABS((pixVector.x/curDCM.pwidth) - _curvedPath.leftTransverseSectionPosition)*curDCM.pwidth < 10.0) || (ABS((pixVector.x/curDCM.pwidth) - _curvedPath.rightTransverseSectionPosition)*curDCM.pwidth < 10.0)))
+		if( self.curDCM.pwidth != 0 && exportTransverseSliceInterval == 0 && _displayTransverseLines && ((ABS((pixVector.x/self.curDCM.pwidth) - _curvedPath.transverseSectionPosition)*self.curDCM.pwidth < 5.0) || (ABS((pixVector.x/self.curDCM.pwidth) - _curvedPath.leftTransverseSectionPosition)*self.curDCM.pwidth < 10.0) || (ABS((pixVector.x/self.curDCM.pwidth) - _curvedPath.rightTransverseSectionPosition)*self.curDCM.pwidth < 10.0)))
 		{
 			if( [theEvent type] == NSLeftMouseDragged || [theEvent type] == NSLeftMouseDown)
 				[[NSCursor closedHandCursor] set];
@@ -907,7 +907,7 @@ extern int splitPosition[ 3];
     
     viewPoint = [self convertPoint:[event locationInWindow] fromView:nil];
     pixVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(viewPoint), [self viewToPixTransform]);
-    pixWidth = curDCM.pwidth;
+    pixWidth = self.curDCM.pwidth;
     _clickedNode = NO;
     
     if (pixWidth == 0.0) {
@@ -939,7 +939,7 @@ extern int splitPosition[ 3];
             relativePosition = [_curvedPath relativePositionForNodeAtIndex:i];
             
             if (N3VectorDistance(N3VectorMakeFromNSPoint(viewPoint),
-                                  N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth*relativePosition, (CGFloat)curDCM.pheight/2.0, 0), N3AffineTransformInvert([self viewToPixTransform]))) < 10.0) {
+                                  N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth*relativePosition, (CGFloat)self.curDCM.pheight/2.0, 0), N3AffineTransformInvert([self viewToPixTransform]))) < 10.0) {
                 if ([_delegate respondsToSelector:@selector(CPRView:setCrossCenter:)]) {
                     [_delegate CPRView: [[self windowController] mprView1] setCrossCenter:[[_curvedPath.nodes objectAtIndex:i] N3VectorValue]];
                 }
@@ -1032,7 +1032,7 @@ extern int splitPosition[ 3];
 	
     viewPoint = [self convertPoint:[event locationInWindow] fromView:nil];
     pixVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(viewPoint), [self viewToPixTransform]);
-    pixWidth = curDCM.pwidth;
+    pixWidth = self.curDCM.pwidth;
     
     if (pixWidth == 0.0) {
         [super mouseDragged:event];
@@ -1106,8 +1106,8 @@ extern int splitPosition[ 3];
 	{
         float factor = 0.4;
         
-        if( curDCM.pixelSpacingX)
-            factor = curDCM.pixelSpacingX;
+        if( self.curDCM.pixelSpacingX)
+            factor = self.curDCM.pixelSpacingX;
         
 		CGFloat transverseSectionSpacing = MIN(MAX(_curvedPath.transverseSectionSpacing + [theEvent deltaY] * factor, 0.0), 300);
 		
@@ -1162,7 +1162,7 @@ extern int splitPosition[ 3];
 	NSPoint previousOrigin = [self origin];
 	float previousScale = [self scaleValue];
 	float previousRotation = [self rotation];
-	int previousHeight = [curDCM pheight], previousWidth = [curDCM pwidth];
+	int previousHeight = [self.curDCM pheight], previousWidth = [self.curDCM pwidth];
 	NSData *previousROIs = [NSArchiver archivedDataWithRootObject: [self curRoiList]];
 	
 	[[self.curvedVolumeData retain] autorelease]; // make sure this is around long enough so that it doesn't disapear under the old DCMPix
@@ -1204,7 +1204,7 @@ extern int splitPosition[ 3];
 		
 		[self setFusion:[[self class] _fusionModeForCPRViewClippingRangeMode:_clippingRangeMode] :self.curvedVolumeData.pixelsDeep];
 		
-		if( previousWidth == [curDCM pwidth] && previousHeight == [curDCM pheight])
+		if( previousWidth == [self.curDCM pwidth] && previousHeight == [self.curDCM pheight])
 		{
 			[self setOrigin:previousOrigin];
 			[self setScaleValue: previousScale];
@@ -1214,8 +1214,8 @@ extern int splitPosition[ 3];
 		NSArray *roiArray = [NSUnarchiver unarchiveObjectWithData: previousROIs];
 		for( ROI *r in roiArray)
 		{
-			r.pix = curDCM;
-			[r setOriginAndSpacing :curDCM.pixelSpacingX : curDCM.pixelSpacingY :NSMakePoint( curDCM.originX, curDCM.originY) :NO :NO];
+			r.pix = self.curDCM;
+			[r setOriginAndSpacing :self.curDCM.pixelSpacingX : self.curDCM.pixelSpacingY :NSMakePoint( self.curDCM.originX, self.curDCM.originY) :NO :NO];
 			[r setCurView:self];
 		}
 		
@@ -1410,12 +1410,12 @@ extern int splitPosition[ 3];
 				
 				if( fabs( A.x - B.x) > 4 || fabs( A.y - B.y) > 4)
 				{
-					if( fabs( A.x - B.x) > fabs( A.y - B.y) || A.y == [curDCM pheight] / 2)
+					if( fabs( A.x - B.x) > fabs( A.y - B.y) || A.y == [self.curDCM pheight] / 2)
 					{
 						// Horizontal length -> centered in y, and horizontal
 						
-						A.y = [curDCM pheight] / 2;
-						B.y = [curDCM pheight] / 2;
+						A.y = [self.curDCM pheight] / 2;
+						B.y = [self.curDCM pheight] / 2;
 						
 						[[points objectAtIndex: 0] setPoint: A];
 						[[points objectAtIndex: 1] setPoint: B];
@@ -1458,7 +1458,7 @@ extern int splitPosition[ 3];
     glMultMatrixd(pixToSubdrawRectOpenGLTransform);    
 	for (indexNumber in verticalLines) {
 		lineStart = N3VectorMake([indexNumber doubleValue], 0, 0);
-        lineEnd = N3VectorMake([indexNumber doubleValue], curDCM.pheight, 0);
+        lineEnd = N3VectorMake([indexNumber doubleValue], self.curDCM.pheight, 0);
         glBegin(GL_LINE_STRIP);
         glVertex2d(lineStart.x, lineStart.y);
         glVertex2d(lineEnd.x, lineEnd.y);
@@ -1480,8 +1480,8 @@ extern int splitPosition[ 3];
 	if( cgl_ctx == nil)
         return;
     
-	pixelsPerMm = (CGFloat)curDCM.pwidth/[_curvedPath.bezierPath length];
-    pheight_2 = (CGFloat)curDCM.pheight/2.0;
+	pixelsPerMm = (CGFloat)self.curDCM.pwidth/[_curvedPath.bezierPath length];
+    pheight_2 = (CGFloat)self.curDCM.pheight/2.0;
     
     N3AffineTransformGetOpenGLMatrixd([self pixToSubDrawRectTransform], pixToSubdrawRectOpenGLTransform);
     glMatrixMode(GL_MODELVIEW);
@@ -1520,8 +1520,8 @@ extern int splitPosition[ 3];
 	NSInteger prevAboveOrBelow;
 
 
-	points = malloc(curDCM.pwidth * sizeof(N3Vector));
-	normals = malloc(curDCM.pwidth * sizeof(N3Vector));
+	points = malloc(self.curDCM.pwidth * sizeof(N3Vector));
+	normals = malloc(self.curDCM.pwidth * sizeof(N3Vector));
 	runs = [NSMutableArray array];
 	planeRun = nil;
 
@@ -1532,9 +1532,9 @@ extern int splitPosition[ 3];
 		verticalLines = nil;
 	}
 	
-	mmPerPixel = [_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth;
-	halfHeight = ((CGFloat)curDCM.pheight*mmPerPixel)/2.0;
-	numVectors = N3BezierCoreGetVectorInfo([_curvedPath.bezierPath N3BezierCore], [_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth, 0, _curvedPath.initialNormal, points, NULL, normals, curDCM.pwidth);
+	mmPerPixel = [_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth;
+	halfHeight = ((CGFloat)self.curDCM.pheight*mmPerPixel)/2.0;
+	numVectors = N3BezierCoreGetVectorInfo([_curvedPath.bezierPath N3BezierCore], [_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth, 0, _curvedPath.initialNormal, points, NULL, normals, self.curDCM.pwidth);
 	
 	for (i = 0; i < numVectors; i++) {
 		bottom = N3VectorAdd(points[i], N3VectorScalarMultiply(normals[i], -halfHeight));
@@ -1663,11 +1663,11 @@ extern int splitPosition[ 3];
 	pixToViewTransform = N3AffineTransformInvert([self viewToPixTransform]);
 	minDistance = CGFLOAT_MAX;
 	pixPointVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(point), [self viewToPixTransform]);
-	pixelsPerMm = (CGFloat)curDCM.pwidth/[_curvedPath.bezierPath length];
+	pixelsPerMm = (CGFloat)self.curDCM.pwidth/[_curvedPath.bezierPath length];
 
 	for (indexNumber in verticalLines) {
 		lineStart = N3VectorMake([indexNumber doubleValue], 0, 0);
-        lineEnd = N3VectorMake([indexNumber doubleValue], curDCM.pheight, 0);
+        lineEnd = N3VectorMake([indexNumber doubleValue], self.curDCM.pheight, 0);
 		
 		distance = N3VectorDistanceToLine(N3VectorMakeFromNSPoint(point), N3LineApplyTransform(N3LineMakeFromPoints(lineStart, lineEnd), pixToViewTransform));
 		if (distance < minDistance) {
@@ -1678,9 +1678,9 @@ extern int splitPosition[ 3];
 			}
 			
 			if (volumeVectorPtr) {
-				relativePosition = [indexNumber doubleValue]/(CGFloat)curDCM.pwidth;
+				relativePosition = [indexNumber doubleValue]/(CGFloat)self.curDCM.pwidth;
 				normalVector = [_curvedPath.bezierPath normalAtRelativePosition:relativePosition initialNormal:_curvedPath.initialNormal];
-				*volumeVectorPtr = N3VectorAdd([_curvedPath.bezierPath vectorAtRelativePosition:relativePosition], N3VectorScalarMultiply(normalVector, (pixPointVector.y - (CGFloat)curDCM.pheight/2.0)/ pixelsPerMm));
+				*volumeVectorPtr = N3VectorAdd([_curvedPath.bezierPath vectorAtRelativePosition:relativePosition], N3VectorScalarMultiply(normalVector, (pixPointVector.y - (CGFloat)self.curDCM.pheight/2.0)/ pixelsPerMm));
 			}
 		}
 	}
@@ -1702,30 +1702,30 @@ extern int splitPosition[ 3];
 	N3MutableBezierPath *planeRunBezierPath;
 	
 	pointVector = N3VectorMakeFromNSPoint(point);
-	pixelsPerMm = (CGFloat)curDCM.pwidth/[_curvedPath.bezierPath length];
+	pixelsPerMm = (CGFloat)self.curDCM.pwidth/[_curvedPath.bezierPath length];
 	minDistance = CGFLOAT_MAX;
 	closestVector = N3VectorZero;
     
 	for (planeRun in planeRuns) {
 		planeRunBezierPath = [[N3MutableBezierPath alloc] initWithCPRStraightenedViewPlaneRun:planeRun heightPixelsPerMm:pixelsPerMm];
-		[planeRunBezierPath applyAffineTransform:N3AffineTransformMakeTranslation(0, (CGFloat)curDCM.pheight/2.0, 0)];
+		[planeRunBezierPath applyAffineTransform:N3AffineTransformMakeTranslation(0, (CGFloat)self.curDCM.pheight/2.0, 0)];
 		[planeRunBezierPath applyAffineTransform:N3AffineTransformInvert([self viewToPixTransform])];
 		
 		N3BezierCoreRelativePositionClosestToVector([planeRunBezierPath N3BezierCore], pointVector, &closeVector, &distance);
 		if (distance < minDistance) {
 			minDistance = distance;
 			closestVector = N3VectorApplyTransform(closeVector, [self viewToPixTransform]);
-			closestVector.y -= (CGFloat)curDCM.pheight/2.0;
+			closestVector.y -= (CGFloat)self.curDCM.pheight/2.0;
 		}
 		[planeRunBezierPath release];
 		planeRunBezierPath = nil;
 	}
 	
 	if (closestPixVectorPtr) {
-		*closestPixVectorPtr = N3VectorMake(closestVector.x, closestVector.y + (CGFloat)curDCM.pheight/2.0, 0);
+		*closestPixVectorPtr = N3VectorMake(closestVector.x, closestVector.y + (CGFloat)self.curDCM.pheight/2.0, 0);
 	}
 	if (volumeVectorPtr) {
-		relativePosition = closestVector.x/(CGFloat)curDCM.pwidth;
+		relativePosition = closestVector.x/(CGFloat)self.curDCM.pwidth;
 		normalVector = [_curvedPath.bezierPath normalAtRelativePosition:relativePosition initialNormal:_curvedPath.initialNormal];
 		*volumeVectorPtr = N3VectorAdd([_curvedPath.bezierPath vectorAtRelativePosition:relativePosition], N3VectorScalarMultiply(normalVector, closestVector.y / pixelsPerMm));
 	}

--- a/Horos/Sources/CPRStretchedView.m
+++ b/Horos/Sources/CPRStretchedView.m
@@ -376,7 +376,7 @@ extern int splitPosition[ 3];
     if (mode != _clippingRangeMode) {
         _clippingRangeMode = mode;
         
-        if (curDCM) {
+        if (self.curDCM) {
             [self setFusion:[[self class] _fusionModeForCPRViewClippingRangeMode:_clippingRangeMode] :self.curvedVolumeData.pixelsDeep];
         }
         [self _setNeedsNewRequest];
@@ -410,7 +410,7 @@ extern int splitPosition[ 3];
 	{
 		float length = [_curvedPath.bezierPath length];
         
-		NSMutableArray *topLeft = [curDCM.annotationsDictionary objectForKey: @"TopLeft"];
+		NSMutableArray *topLeft = [self.curDCM.annotationsDictionary objectForKey: @"TopLeft"];
 		
 		length *= 0.1; // We want cm
 		
@@ -498,7 +498,7 @@ extern int splitPosition[ 3];
 	glEnable(GL_LINE_SMOOTH);
 	glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	
-    if ([curDCM pixelSpacingX] == 0) {
+    if ([self.curDCM pixelSpacingX] == 0) {
         return;
     }
     
@@ -627,7 +627,7 @@ extern int splitPosition[ 3];
                 glLineWidth(1.0 * self.window.backingScaleFactor);
             }
             
-            [self _drawVerticalLines:transverseVerticalLine length:curDCM.pheight/3.0];
+            [self _drawVerticalLines:transverseVerticalLine length:self.curDCM.pheight/3.0];
         }
         for (name in _transversePlaneRuns) {
             NSArray *transversePlaneRun = [_transversePlaneRuns objectForKey:name];
@@ -757,7 +757,7 @@ extern int splitPosition[ 3];
 //                    break;
 //            }
 //            
-//            cursorVector = N3VectorMake((CGFloat)curDCM.pwidth*relativePosition, ((CGFloat)curDCM.pheight/2.0)+(_displayInfo.mouseTransverseSectionDistance*pixelsPerMm), 0);
+//            cursorVector = N3VectorMake((CGFloat)self.curDCM.pwidth*relativePosition, ((CGFloat)self.curDCM.pheight/2.0)+(_displayInfo.mouseTransverseSectionDistance*pixelsPerMm), 0);
 //            cursorVector = N3VectorApplyTransform(cursorVector, pixToSubDrawRectTransform);
 //            
 //            glColor4d(1.0, 1.0, 0.0, 1.0);
@@ -775,7 +775,7 @@ extern int splitPosition[ 3];
 		{
             relativePosition = [_curvedPath relativePositionForNodeAtIndex:i];
             cursorVector = [self _centerlinePixVectorForRelativePosition:relativePosition];
-//            cursorVector = N3VectorMake(curDCM.pwidth * relativePosition, (CGFloat)curDCM.pheight/2.0, 0);
+//            cursorVector = N3VectorMake(self.curDCM.pwidth * relativePosition, (CGFloat)self.curDCM.pheight/2.0, 0);
             cursorVector = N3VectorApplyTransform(cursorVector, pixToSubDrawRectTransform);
             
             if (_displayInfo.hoverNodeHidden == NO && _displayInfo.hoverNodeIndex == i)
@@ -842,7 +842,7 @@ extern int splitPosition[ 3];
 	NSPoint previousOrigin = [self origin];
 	float previousScale = [self scaleValue];
 	float previousRotation = [self rotation];
-	int previousHeight = [curDCM pheight], previousWidth = [curDCM pwidth];
+	int previousHeight = [self.curDCM pheight], previousWidth = [self.curDCM pwidth];
 	NSData *previousROIs = [NSArchiver archivedDataWithRootObject: [self curRoiList]];
 	
 	[[self.curvedVolumeData retain] autorelease]; // make sure this is around long enough so that it doesn't disapear under the old DCMPix
@@ -895,7 +895,7 @@ extern int splitPosition[ 3];
 		
 		[self setFusion:[[self class] _fusionModeForCPRViewClippingRangeMode:_clippingRangeMode] :self.curvedVolumeData.pixelsDeep];
 		
-		if( previousWidth == [curDCM pwidth] && previousHeight == [curDCM pheight])
+		if( previousWidth == [self.curDCM pwidth] && previousHeight == [self.curDCM pheight])
 		{
 			[self setOrigin:previousOrigin];
 			[self setScaleValue: previousScale];
@@ -905,8 +905,8 @@ extern int splitPosition[ 3];
 		NSArray *roiArray = [NSUnarchiver unarchiveObjectWithData: previousROIs];
 		for( ROI *r in roiArray)
 		{
-			r.pix = curDCM;
-			[r setOriginAndSpacing :curDCM.pixelSpacingX : curDCM.pixelSpacingY :NSMakePoint( curDCM.originX, curDCM.originY) :NO :NO];
+			r.pix = self.curDCM;
+			[r setOriginAndSpacing :self.curDCM.pixelSpacingX : self.curDCM.pixelSpacingY :NSMakePoint( self.curDCM.originX, self.curDCM.originY) :NO :NO];
 			[r setCurView:self];
 		}
 		
@@ -974,10 +974,10 @@ extern int splitPosition[ 3];
 		
 		pixVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(viewPoint), [self viewToPixTransform]);
 		
-		if (NSPointInRect(viewPoint, self.bounds) && curDCM.pwidth > 0) {
+		if (NSPointInRect(viewPoint, self.bounds) && self.curDCM.pwidth > 0) {
 			[self _sendWillEditDisplayInfo];
 			_displayInfo.mouseCursorPosition = [self _relativePositionForPixPoint:NSPointFromN3Vector(pixVector)];
-//			_displayInfo.mouseCursorPosition = MIN(MAX(pixVector.x/(CGFloat)curDCM.pwidth, 0.0), 1.0);
+//			_displayInfo.mouseCursorPosition = MIN(MAX(pixVector.x/(CGFloat)self.curDCM.pwidth, 0.0), 1.0);
 			[self setNeedsDisplay:YES];
             
 			[self _updateMousePlanePointsForViewPoint:viewPoint];  // this will modify _mousePlanePointsInPix and _displayInfo
@@ -986,26 +986,26 @@ extern int splitPosition[ 3];
 //            _displayInfo.mouseTransverseSection = CPRTransverseViewNoneSectionType;
 //            _displayInfo.mouseTransverseSectionDistance = 0.0;
 //            if (_displayTransverseLines) {
-//                distance = ABS(pixVector.x - _curvedPath.leftTransverseSectionPosition*(CGFloat)curDCM.pwidth);
+//                distance = ABS(pixVector.x - _curvedPath.leftTransverseSectionPosition*(CGFloat)self.curDCM.pwidth);
 //                minDistance = distance;
 //                if (distance < 20.0) {
 //                    _displayInfo.mouseTransverseSection = CPRTransverseViewLeftSectionType;
-//                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth);
+//                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)self.curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth);
 //                }
-//                distance = ABS(pixVector.x - _curvedPath.rightTransverseSectionPosition*(CGFloat)curDCM.pwidth);
+//                distance = ABS(pixVector.x - _curvedPath.rightTransverseSectionPosition*(CGFloat)self.curDCM.pwidth);
 //                if (distance < 20.0 && distance < minDistance) {
 //                    _displayInfo.mouseTransverseSection = CPRTransverseViewRightSectionType;
-//                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth);
+//                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)self.curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth);
 //                    minDistance = distance;
 //                }
-//                distance = ABS(pixVector.x - _curvedPath.transverseSectionPosition*(CGFloat)curDCM.pwidth);
+//                distance = ABS(pixVector.x - _curvedPath.transverseSectionPosition*(CGFloat)self.curDCM.pwidth);
 //                if (distance < 20.0 && distance < minDistance) {
 //                    _displayInfo.mouseTransverseSection = CPRTransverseViewCenterSectionType;
-//                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)curDCM.pwidth);
+//                    _displayInfo.mouseTransverseSectionDistance = (pixVector.y - ((CGFloat)self.curDCM.pheight/2.0))*([_curvedPath.bezierPath length]/(CGFloat)self.curDCM.pwidth);
 //                }
 //            }            
             
-//			line = N3LineMake(N3VectorMake(0, (CGFloat)curDCM.pheight / 2.0, 0), N3VectorMake(1, 0, 0));
+//			line = N3LineMake(N3VectorMake(0, (CGFloat)self.curDCM.pheight / 2.0, 0), N3VectorMake(1, 0, 0));
 //			line = N3LineApplyTransform(line, N3AffineTransformInvert([self viewToPixTransform]));
 //			
             
@@ -1069,7 +1069,7 @@ extern int splitPosition[ 3];
         transverseLineDistance = [self _distanceToPoint:viewPoint onVerticalLines:allTransverseVerticalLines pixVector:NULL volumeVector:NULL];
         transverseRunDistance = [self _distanceToPoint:viewPoint onPlaneRuns:allTransverseRuns pixVector:NULL volumeVector:NULL];
 
-		if( curDCM.pwidth != 0 && exportTransverseSliceInterval == 0 && _displayTransverseLines && (transverseLineDistance < 5.0 || transverseRunDistance < 5.0))
+		if( self.curDCM.pwidth != 0 && exportTransverseSliceInterval == 0 && _displayTransverseLines && (transverseLineDistance < 5.0 || transverseRunDistance < 5.0))
 		{
 			if( [theEvent type] == NSLeftMouseDragged || [theEvent type] == NSLeftMouseDown)
 				[[NSCursor closedHandCursor] set];
@@ -1101,7 +1101,7 @@ extern int splitPosition[ 3];
     
     viewPoint = [self convertPoint:[event locationInWindow] fromView:nil];
     pixVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(viewPoint), [self viewToPixTransform]);
-    pixWidth = curDCM.pwidth;
+    pixWidth = self.curDCM.pwidth;
     
     if (pixWidth == 0.0) {
         [super mouseDown:event];
@@ -1269,7 +1269,7 @@ extern int splitPosition[ 3];
     	
     viewPoint = [self convertPoint:[event locationInWindow] fromView:nil];
     pixVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(viewPoint), [self viewToPixTransform]);
-    pixWidth = curDCM.pwidth;
+    pixWidth = self.curDCM.pwidth;
     
     if (pixWidth == 0.0) {
         [super mouseDragged:event];
@@ -1387,8 +1387,8 @@ extern int splitPosition[ 3];
 	{
         float factor = 0.4;
         
-        if( curDCM.pixelSpacingX)
-            factor = curDCM.pixelSpacingX;
+        if( self.curDCM.pixelSpacingX)
+            factor = self.curDCM.pixelSpacingX;
         
 		CGFloat transverseSectionSpacing = MIN(MAX(_curvedPath.transverseSectionSpacing + [theEvent deltaY] * factor, 0.0), 300);
 		
@@ -1666,7 +1666,7 @@ extern int splitPosition[ 3];
     glMultMatrixd(pixToSubdrawRectOpenGLTransform);    
 	for (indexNumber in verticalLines) {
 		lineStart = N3VectorMake([indexNumber doubleValue], 0, 0);
-        lineEnd = N3VectorMake([indexNumber doubleValue], curDCM.pheight, 0);
+        lineEnd = N3VectorMake([indexNumber doubleValue], self.curDCM.pheight, 0);
         glBegin(GL_LINE_STRIP);
         glVertex2d(lineStart.x, lineStart.y);
         glVertex2d(lineEnd.x, lineEnd.y);
@@ -1721,13 +1721,13 @@ extern int splitPosition[ 3];
   	if( cgl_ctx == nil)
         return;
     
-    if ([curDCM pixelSpacingX] == 0) {
+    if ([self.curDCM pixelSpacingX] == 0) {
         return;
     }
     
-    pixelsPerMm = 1.0/[curDCM pixelSpacingX];
+    pixelsPerMm = 1.0/[self.curDCM pixelSpacingX];
 
-    pheight_2 = (CGFloat)curDCM.pheight/2.0;
+    pheight_2 = (CGFloat)self.curDCM.pheight/2.0;
     
     N3AffineTransformGetOpenGLMatrixd([self pixToSubDrawRectTransform], pixToSubdrawRectOpenGLTransform);
     glMatrixMode(GL_MODELVIEW);
@@ -1778,12 +1778,12 @@ extern int splitPosition[ 3];
     transversePlane.point = [_curvedPath.bezierPath vectorAtRelativePosition:relativePosition];
     transversePlane.normal = [_curvedPath.bezierPath tangentAtRelativePosition:relativePosition];
     
-    mmPerPixel = [curDCM pixelSpacingX];
-	halfHeight = ((CGFloat)curDCM.pheight*mmPerPixel)/2.0;
+    mmPerPixel = [self.curDCM pixelSpacingX];
+	halfHeight = ((CGFloat)self.curDCM.pheight*mmPerPixel)/2.0;
     length /= 2.0; // because the rest of the code uses the length from the centerline 
     
     // figure out how many horizonatal pixels we will have
-    pixelsWide = curDCM.pwidth;
+    pixelsWide = self.curDCM.pwidth;
     projectionNormal = _projectionNormal;
     
     midHeightPoint = _midHeightPoint;
@@ -1986,11 +1986,11 @@ extern int splitPosition[ 3];
 		verticalLines = nil;
 	}
 	
-    mmPerPixel = [curDCM pixelSpacingX];
-	halfHeight = ((CGFloat)curDCM.pheight*mmPerPixel)/2.0;
+    mmPerPixel = [self.curDCM pixelSpacingX];
+	halfHeight = ((CGFloat)self.curDCM.pheight*mmPerPixel)/2.0;
     
     // figure out how many horizonatal pixels we will have
-    pixelsWide = curDCM.pwidth;
+    pixelsWide = self.curDCM.pwidth;
     projectionNormal = _projectionNormal;
     
     midHeightPoint = _midHeightPoint;
@@ -2141,7 +2141,7 @@ extern int splitPosition[ 3];
 	CGFloat distance;
 	CGFloat minDistance;
     
-    if ([curDCM pixelSpacingX] == 0 || [verticalLines count] == 0) {
+    if ([self.curDCM pixelSpacingX] == 0 || [verticalLines count] == 0) {
         return CGFLOAT_MAX;
     }
     
@@ -2151,7 +2151,7 @@ extern int splitPosition[ 3];
     
 	for (indexNumber in verticalLines) {
 		lineStart = N3VectorMake([indexNumber doubleValue], 0, 0);
-        lineEnd = N3VectorMake([indexNumber doubleValue], curDCM.pheight, 0);
+        lineEnd = N3VectorMake([indexNumber doubleValue], self.curDCM.pheight, 0);
 		
 		distance = N3VectorDistanceToLine(N3VectorMakeFromNSPoint(point), N3LineApplyTransform(N3LineMakeFromPoints(lineStart, lineEnd), pixToViewTransform));
 		if (distance < minDistance) {
@@ -2181,19 +2181,19 @@ extern int splitPosition[ 3];
 	_CPRStretchedViewPlaneRun *planeRun;
 	N3MutableBezierPath *planeRunBezierPath;
 	
-    if ([curDCM pixelSpacingX] == 0 || [planeRuns count] == 0) {
+    if ([self.curDCM pixelSpacingX] == 0 || [planeRuns count] == 0) {
         return CGFLOAT_MAX;
     }
     
 	pointVector = N3VectorMakeFromNSPoint(point);
-    pixelsPerMm = 1.0/[curDCM pixelSpacingX];
+    pixelsPerMm = 1.0/[self.curDCM pixelSpacingX];
 
 	minDistance = CGFLOAT_MAX;
 	closestVector = N3VectorZero;
     
 	for (planeRun in planeRuns) {
 		planeRunBezierPath = [[N3MutableBezierPath alloc] initWithCPRStretchedViewPlaneRun:planeRun heightPixelsPerMm:pixelsPerMm];
-		[planeRunBezierPath applyAffineTransform:N3AffineTransformMakeTranslation(0, (CGFloat)curDCM.pheight/2.0, 0)];
+		[planeRunBezierPath applyAffineTransform:N3AffineTransformMakeTranslation(0, (CGFloat)self.curDCM.pheight/2.0, 0)];
 		[planeRunBezierPath applyAffineTransform:N3AffineTransformInvert([self viewToPixTransform])];
 		
 		N3BezierCoreRelativePositionClosestToVector([planeRunBezierPath N3BezierCore], pointVector, &closeVector, &distance);
@@ -2402,7 +2402,7 @@ extern int splitPosition[ 3];
     NSArray *intersections;
     N3Vector relativePositionIntersection;
     
-    if ([curDCM pixelSpacingX] == 0) {
+    if ([self.curDCM pixelSpacingX] == 0) {
         return N3VectorZero;
     }
     
@@ -2470,7 +2470,7 @@ extern int splitPosition[ 3];
     N3Vector projectionNormal;
         
     projectionNormal = _projectionNormal;
-    mmPerPixel = [curDCM pixelSpacingX];
+    mmPerPixel = [self.curDCM pixelSpacingX];
     intersectionPlane = N3PlaneMake(N3VectorMakeFromNSPoint(pixPoint), N3VectorMake(1.0, 0, 0));
     intersections = [_centerlinePath intersectionsWithPlane:intersectionPlane];
     if ([intersections count] == 0) {

--- a/Horos/Sources/CPRTransverseView.m
+++ b/Horos/Sources/CPRTransverseView.m
@@ -261,7 +261,7 @@ extern int splitPosition[ 3];
 
 - (float) pixelsPerMm
 {
-    return (CGFloat)curDCM.pwidth/(_sectionWidth / _renderingScale);
+    return (CGFloat)self.curDCM.pwidth/(_sectionWidth / _renderingScale);
 }
 
 - (void)mouseMoved:(NSEvent *)theEvent
@@ -278,17 +278,17 @@ extern int splitPosition[ 3];
 	{
 		viewPoint = [self convertPoint:[theEvent locationInWindow] fromView:nil];
 		
-		if (NSPointInRect(viewPoint, self.bounds) && curDCM.pwidth > 0)
+		if (NSPointInRect(viewPoint, self.bounds) && self.curDCM.pwidth > 0)
 		{
 			pixVector = N3VectorApplyTransform(N3VectorMakeFromNSPoint(viewPoint), [self viewToPixTransform]);
 			pixelsPerMm = self.pixelsPerMm;
 		
-			line = N3LineMake(N3VectorMake((CGFloat)curDCM.pwidth / 2.0, 0, 0), N3VectorMake(0, 1, 0));
+			line = N3LineMake(N3VectorMake((CGFloat)self.curDCM.pwidth / 2.0, 0, 0), N3VectorMake(0, 1, 0));
 			line = N3LineApplyTransform(line, N3AffineTransformInvert([self viewToPixTransform]));
 			
 			if (N3VectorDistanceToLine(N3VectorMakeFromNSPoint(viewPoint), line) < 20.0) {
 				newMouseTransverseSectionType = _sectionType;
-				newMouseTransverseSectionDistance = (pixVector.y - (CGFloat)curDCM.pheight/2.0) / pixelsPerMm;
+				newMouseTransverseSectionDistance = (pixVector.y - (CGFloat)self.curDCM.pheight/2.0) / pixelsPerMm;
 			} else {
 				newMouseTransverseSectionType = CPRTransverseViewNoneSectionType;
 				newMouseTransverseSectionDistance = 0;
@@ -472,7 +472,7 @@ extern int splitPosition[ 3];
 		ROI *r = [rArray objectAtIndex:i];
 		
 		r.displayCMOrPixels = YES; // We don't want the value in pixels
-		r.imageOrigin = NSMakePoint( curDCM.originX, curDCM.originY);
+		r.imageOrigin = NSMakePoint( self.curDCM.originX, self.curDCM.originY);
 		
 		if( r.type == t3Dpoint || r.type == t2DPoint)
 		{
@@ -506,8 +506,8 @@ extern int splitPosition[ 3];
 //	if( displayCrossLines && _reformationDisplayStyle == CPRTransverseViewStraightenedReformationDisplayStyle)
 //	{
 //		glColor4d(1.0, 1.0, 0.0, 1.0);
-//		lineStart = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth/2.0, 0, 0), pixToSubDrawRectTransform);
-//		lineEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth/2.0, curDCM.pheight, 0), pixToSubDrawRectTransform);
+//		lineStart = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth/2.0, 0, 0), pixToSubDrawRectTransform);
+//		lineEnd = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth/2.0, self.curDCM.pheight, 0), pixToSubDrawRectTransform);
 //		glLineWidth(1.0 * self.window.backingScaleFactor);
 //		glBegin(GL_LINE_STRIP);
 //		glVertex2f(lineStart.x, lineStart.y);
@@ -518,12 +518,12 @@ extern int splitPosition[ 3];
 //		{
 //			glLineWidth(1.0 * self.window.backingScaleFactor);
 //			glBegin(GL_LINES);
-//			lineStart = N3VectorApplyTransform(N3VectorMake(((CGFloat)curDCM.pwidth+_curvedPath.thickness*pixelsPerMm)/2.0, 0, 0), pixToSubDrawRectTransform);
-//			lineEnd = N3VectorApplyTransform(N3VectorMake(((CGFloat)curDCM.pwidth+_curvedPath.thickness*pixelsPerMm)/2.0, curDCM.pheight, 0), pixToSubDrawRectTransform);
+//			lineStart = N3VectorApplyTransform(N3VectorMake(((CGFloat)self.curDCM.pwidth+_curvedPath.thickness*pixelsPerMm)/2.0, 0, 0), pixToSubDrawRectTransform);
+//			lineEnd = N3VectorApplyTransform(N3VectorMake(((CGFloat)self.curDCM.pwidth+_curvedPath.thickness*pixelsPerMm)/2.0, self.curDCM.pheight, 0), pixToSubDrawRectTransform);
 //			glVertex2f(lineStart.x, lineStart.y);
 //			glVertex2f(lineEnd.x, lineEnd.y);
-//			lineStart = N3VectorApplyTransform(N3VectorMake(((CGFloat)curDCM.pwidth-_curvedPath.thickness*pixelsPerMm)/2.0, 0, 0), pixToSubDrawRectTransform);
-//			lineEnd = N3VectorApplyTransform(N3VectorMake(((CGFloat)curDCM.pwidth-_curvedPath.thickness*pixelsPerMm)/2.0, curDCM.pheight, 0), pixToSubDrawRectTransform);
+//			lineStart = N3VectorApplyTransform(N3VectorMake(((CGFloat)self.curDCM.pwidth-_curvedPath.thickness*pixelsPerMm)/2.0, 0, 0), pixToSubDrawRectTransform);
+//			lineEnd = N3VectorApplyTransform(N3VectorMake(((CGFloat)self.curDCM.pwidth-_curvedPath.thickness*pixelsPerMm)/2.0, self.curDCM.pheight, 0), pixToSubDrawRectTransform);
 //			glVertex2f(lineStart.x, lineStart.y);
 //			glVertex2f(lineEnd.x, lineEnd.y);
 //			glEnd();
@@ -531,7 +531,7 @@ extern int splitPosition[ 3];
 //	}
     
     if( [[self windowController] displayMousePosition] == YES && _displayInfo.mouseTransverseSection == _sectionType) {
-        cursorVector = N3VectorMake(((CGFloat)curDCM.pwidth)/2.0, ((CGFloat)curDCM.pheight/2.0)+(_displayInfo.mouseTransverseSectionDistance*pixelsPerMm), 0);
+        cursorVector = N3VectorMake(((CGFloat)self.curDCM.pwidth)/2.0, ((CGFloat)self.curDCM.pheight/2.0)+(_displayInfo.mouseTransverseSectionDistance*pixelsPerMm), 0);
         cursorVector = N3VectorApplyTransform(cursorVector, pixToSubDrawRectTransform);
         
         glColor4d(1.0, 1.0, 0.0, 1.0);
@@ -665,8 +665,8 @@ extern int splitPosition[ 3];
 		NSArray *roiArray = [NSUnarchiver unarchiveObjectWithData: previousROIs];
 		for( ROI *r in roiArray)
 		{
-			r.pix = curDCM;
-			[r setOriginAndSpacing :curDCM.pixelSpacingX : curDCM.pixelSpacingY :NSMakePoint( curDCM.originX, curDCM.originY) :NO :NO];
+			r.pix = self.curDCM;
+			[r setOriginAndSpacing :self.curDCM.pixelSpacingX : self.curDCM.pixelSpacingY :NSMakePoint( self.curDCM.originX, self.curDCM.originY) :NO :NO];
 			[r setCurView:self];
 		}
 		

--- a/Horos/Sources/DCMPix.h
+++ b/Horos/Sources/DCMPix.h
@@ -75,7 +75,7 @@ extern "C"
 
 @interface DCMPix: NSObject <NSCopying>
 {
-    NSString            *srcFile;  /**< source File */
+    NSString            *_srcFile;  /**< source File */
     NSString            *URIRepresentationAbsoluteString;
     BOOL				isBonjour;
     BOOL                fileTypeHasPrefixDICOM;
@@ -315,7 +315,7 @@ extern "C"
 @property(readonly) BOOL generated;
 @property(retain) NSString *generatedName;
 
-@property(retain) NSString *srcFile;
+@property(strong) NSString *srcFile;
 - (NSString *)sourceFile __deprecated;
 - (void)setSourceFile:(NSString *)sf __deprecated;
 
@@ -344,7 +344,7 @@ extern "C"
 @property BOOL isLUT12Bit;
 
 // Waveform
-@property(readonly,retain) DCMWaveform* waveform;
+@property(readonly,strong) DCMWaveform* waveform;
 
 // US Regions
 @property(readonly) NSMutableArray *usRegions;

--- a/Horos/Sources/DCMPix.m
+++ b/Horos/Sources/DCMPix.m
@@ -1336,7 +1336,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
 
 @interface DCMPix ()
 
-@property(readwrite,retain) DCMWaveform* waveform;
+@property(strong) DCMWaveform *waveform;
 
 @end
 
@@ -1358,7 +1358,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
 @synthesize serieNo, pixArray, pixPos, transferFunctionPtr;
 @synthesize stackMode, generated, generatedName, imageObjectID;
 
-@synthesize srcFile;
+@synthesize srcFile = _srcFile;
 
 @synthesize annotationsDictionary, annotationsDBFields, yearOld, yearOldAcquisition;
 
@@ -3422,7 +3422,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     orientation[6] = orientation[1]*orientation[5] - orientation[2]*orientation[4];
     orientation[7] = orientation[2]*orientation[3] - orientation[0]*orientation[5];
     orientation[8] = orientation[0]*orientation[4] - orientation[1]*orientation[3];
-    srcFile = nil;
+    self.srcFile = nil;
     generated = YES;
     self.rescaleType = @"";
     
@@ -3642,7 +3642,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     if( self = [super init])
     {
         //-------------------------received parameters
-        srcFile = [s retain];
+        self.srcFile = s;
         
         [iO.managedObjectContext lock];
         @try
@@ -3705,13 +3705,13 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     return [self initWithPath: s :pos :tot :ptr :f :ss isBonjour:NO imageObj: nil];
 }
 
-- (id) copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(NSZone *)zone
 {
-    DCMPix *copy = [[DCMPix allocWithZone: zone] init];
-    if( copy == nil)
+    DCMPix *copy = [[DCMPix allocWithZone:zone] init];
+    if (!copy)
         return nil;
     
-    copy->srcFile = [self->srcFile retain];
+    copy->_srcFile = [self->_srcFile retain];
     copy->imageObjectID = [self->imageObjectID retain];
     copy->URIRepresentationAbsoluteString = [self->URIRepresentationAbsoluteString retain];
     copy->fileTypeHasPrefixDICOM = self->fileTypeHasPrefixDICOM;
@@ -3799,7 +3799,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
 
 -(void) LoadBioradPic
 {
-    FILE		*fp = fopen( [srcFile UTF8String], "r");
+    FILE		*fp = fopen(self.srcFile.UTF8String, "r");
     long		i;
     
     //NSLog(@"Handling Biorad PIC File in CheckLoad");
@@ -4032,7 +4032,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     
     isRGB = NO;
     
-    TIFF* tif = TIFFOpen([srcFile UTF8String], "r");
+    TIFF* tif = TIFFOpen(self.srcFile.UTF8String, "r");
     if( tif)
     {
         count = 0;
@@ -4380,7 +4380,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     short head_size = 0;
     char* head_data = 0;
     int NoOfFrames = 1, NoOfSeries = 1;
-    TIFF* tif = TIFFOpen([srcFile UTF8String], "r");
+    TIFF* tif = TIFFOpen(self.srcFile.UTF8String, "r");
     if(tif)
         success = TIFFGetField(tif, TIFFTAG_FV_MMHEADER, &head_size, &head_data);
     if (success)
@@ -4440,7 +4440,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     // This function has been modified twice by Greg Jefferis on 9 June 2004
     // early am and late pm respectively.  After the second iteration it has been
     // tested on new and old style 16 and 8 bit LSM tiff files.  Comments?
-    FILE *fp = fopen( [srcFile UTF8String], "r");
+    FILE *fp = fopen(self.srcFile.UTF8String, "r");
     int	i,it = 0;
     int	nextoff = 0;
     int counter = 0;
@@ -5817,7 +5817,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
 - (BOOL)loadDICOMDCMFramework
 {
     // Memory test: DCMFramework requires a lot of memory...
-    unsigned long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath: srcFile error: nil] fileSize];
+    unsigned long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:self.srcFile error:NULL] fileSize];
     fileSize *= 1.5;
     
     void *memoryTest = malloc( fileSize);
@@ -5844,21 +5844,21 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     
     @try
     {
-        if( [cachedDCMFrameworkFiles objectForKey: srcFile])
+        if( [cachedDCMFrameworkFiles objectForKey:self.srcFile])
         {
-            NSMutableDictionary *dic = [cachedDCMFrameworkFiles objectForKey: srcFile];
+            NSMutableDictionary *dic = [cachedDCMFrameworkFiles objectForKey:self.srcFile];
             
             dcmObject = [dic objectForKey: @"dcmObject"];
             
             if( retainedCacheGroup != nil)
-                NSLog( @"******** DCMPix : retainedCacheGroup 3 != nil ! %@", srcFile);
+                NSLog( @"******** DCMPix : retainedCacheGroup 3 != nil ! %@", self.srcFile);
             
             [dic setValue: [NSNumber numberWithInt: [[dic objectForKey: @"count"] intValue]+1] forKey: @"count"];
             retainedCacheGroup = dic;
         }
         else
         {
-            dcmObject = [DCMObject objectWithContentsOfFile:srcFile decodingPixelData:NO];
+            dcmObject = [DCMObject objectWithContentsOfFile:self.srcFile decodingPixelData:NO];
             
             if( dcmObject)
             {
@@ -5866,12 +5866,12 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                 
                 [dic setValue: dcmObject forKey: @"dcmObject"];
                 if( retainedCacheGroup != nil)
-                    NSLog( @"******** DCMPix : retainedCacheGroup 4 != nil ! %@", srcFile);
+                    NSLog( @"******** DCMPix : retainedCacheGroup 4 != nil ! %@", self.srcFile);
                 
                 [dic setValue: [NSNumber numberWithInt: 1] forKey: @"count"];
                 retainedCacheGroup = dic;
                 
-                [cachedDCMFrameworkFiles setObject: dic forKey: srcFile];
+                [cachedDCMFrameworkFiles setObject:dic forKey:self.srcFile];
             }
         }
     }
@@ -5943,14 +5943,14 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
         {
             [[NSFileManager defaultManager] confirmDirectoryAtPath:@"/tmp/dicomsr_osirix/"];
             
-            NSString *htmlpath = [[@"/tmp/dicomsr_osirix/" stringByAppendingPathComponent: [srcFile lastPathComponent]] stringByAppendingPathExtension: @"xml"];
+            NSString *htmlpath = [[@"/tmp/dicomsr_osirix/" stringByAppendingPathComponent:self.srcFile.lastPathComponent] stringByAppendingPathExtension: @"xml"];
             
             if( [[NSFileManager defaultManager] fileExistsAtPath: htmlpath] == NO)
             {
                 NSTask *aTask = [[[NSTask alloc] init] autorelease];
                 [aTask setEnvironment:[NSDictionary dictionaryWithObject:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"/dicom.dic"] forKey:@"DCMDICTPATH"]];
                 [aTask setLaunchPath: [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent: @"/dsr2html"]];
-                [aTask setArguments: [NSArray arrayWithObjects: @"+X1", @"--unknown-relationship", @"--ignore-constraints", @"--ignore-item-errors", @"--skip-invalid-items",srcFile, htmlpath, nil]];
+                [aTask setArguments: [NSArray arrayWithObjects: @"+X1", @"--unknown-relationship", @"--ignore-constraints", @"--ignore-item-errors", @"--skip-invalid-items",self.srcFile, htmlpath, nil]];
                 [aTask launch];
                 while( [aTask isRunning])
                     [NSThread sleepForTimeInterval: 0.1];
@@ -6928,7 +6928,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     {
         if( fImage)
         {
-            NSMutableDictionary *cachedGroupsForThisFile = [cachedDCMFrameworkFiles valueForKey: srcFile];
+            NSMutableDictionary *cachedGroupsForThisFile = [cachedDCMFrameworkFiles valueForKey:self.srcFile];
             
             if( cachedGroupsForThisFile && retainedCacheGroup == cachedGroupsForThisFile)
             {
@@ -6937,7 +6937,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                 
                 if( [[cachedGroupsForThisFile objectForKey: @"count"] intValue] <= 0)
                 {
-                    [cachedDCMFrameworkFiles removeObjectForKey: srcFile];
+                    [cachedDCMFrameworkFiles removeObjectForKey:self.srcFile];
                 }
             }
         }
@@ -6956,7 +6956,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     
     @try
     {
-        NSMutableDictionary *cachedGroupsForThisFile = [cachedPapyGroups valueForKey: srcFile];
+        NSMutableDictionary *cachedGroupsForThisFile = [cachedPapyGroups valueForKey:self.srcFile];
         if( cachedGroupsForThisFile && retainedCacheGroup == cachedGroupsForThisFile)
         {
             [cachedGroupsForThisFile setValue: [NSNumber numberWithInt: [[cachedGroupsForThisFile objectForKey: @"count"] intValue]-1] forKey: @"count"];
@@ -7179,32 +7179,30 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
         
         if( runOsiriXInProtectedMode) return;
         
-        if( srcFile == nil) return;
+        if (!self.srcFile) return;
         
         if( isBonjour)
         {
 #ifdef OSIRIX_VIEWER
             // LOAD THE FILE FROM BONJOUR SHARED DATABASE
             
-            [srcFile release];
-            srcFile = nil;
+            self.srcFile = nil;
             
             if( [NSThread isMainThread])
             {
-                srcFile = [[BrowserController currentBrowser] getLocalDCMPath: [[[BrowserController currentBrowser] database] objectWithID: imageObjectID] :0];
+                self.srcFile = [[BrowserController currentBrowser] getLocalDCMPath: [[[BrowserController currentBrowser] database] objectWithID: imageObjectID] :0];
             }
             else
             {
-                srcFile = [[BrowserController currentBrowser] getLocalDCMPath: [[[[BrowserController currentBrowser] database] independentContext] existingObjectWithID: imageObjectID error: nil] :0];
-                [srcFile retain];
+                self.srcFile = [[BrowserController currentBrowser] getLocalDCMPath: [[[[BrowserController currentBrowser] database] independentContext] existingObjectWithID: imageObjectID error: nil] :0];
             }
             
-            if( srcFile == nil)
+            if(self.srcFile == nil)
                 return;
 #endif
         }
         
-        if( [self isDICOMFile: srcFile])
+        if( [self isDICOMFile:self.srcFile])
         {
             // PLEASE, KEEP BOTH FUNCTIONS FOR TESTING PURPOSE. THANKS
             NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -7231,7 +7229,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                             [URIRepresentationAbsoluteString writeToFile: recoveryPath atomically: YES encoding: NSASCIIStringEncoding  error: nil];
                             
                             //only try again if it's strict DICOM
-                            if (success == NO && [DCMObject isDICOM:[NSData dataWithContentsOfFile: srcFile]])
+                            if (success == NO && [DCMObject isDICOM:[NSData dataWithContentsOfFile:self.srcFile]])
                             {
                                 success = [self loadDICOMDCMFramework];
                             }
@@ -7252,7 +7250,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                     success = [self loadDICOMDCMFramework];
                     
                     if (success == NO &&
-                        [DCMObject isDICOM:[NSData dataWithContentsOfFile:srcFile]]) {
+                        [DCMObject isDICOM:[NSData dataWithContentsOfFile:self.srcFile]]) {
                         success = [self loadDICOMPapyrus];
                     }
                 }
@@ -7266,7 +7264,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
             {
                 NSLog( @"CheckLoadIn Exception");
                 NSLog( @"%@", [e description]);
-                NSLog( @"Exception for this file: %@", srcFile);
+                NSLog( @"Exception for this file: %@", self.srcFile);
                 success = NO;
             }
             
@@ -7278,17 +7276,17 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
         if( success == NO)	// Is it a NON-DICOM IMAGE ??
         {
             NSImage		*otherImage = nil;
-            NSString	*extension = [[srcFile pathExtension] lowercaseString];
+            NSString	*extension = [[self.srcFile pathExtension] lowercaseString];
             
 #ifdef OSIRIX_VIEWER
             id fileFormatBundle;
-            if ((fileFormatBundle = [[PluginManager fileFormatPlugins] objectForKey:[srcFile pathExtension]]))
+            if ((fileFormatBundle = [[PluginManager fileFormatPlugins] objectForKey:[self.srcFile pathExtension]]))
             {
                 PluginFileFormatDecoder *decoder = [[[fileFormatBundle principalClass] alloc] init];
                 
                 [PluginManager startProtectForCrashWithFilter: decoder];
                 
-                fImage = [decoder checkLoadAtPath:srcFile];
+                fImage = [decoder checkLoadAtPath:self.srcFile];
                 //NSLog(@"decoder width %d", [decoder width]);
                 width = [[decoder width] intValue];
                 //width = 832;
@@ -7306,7 +7304,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                 if( [extension isEqualToString:@"zip"])
                 {
                     // the ZIP icon
-                    NSImage *icon = [[NSWorkspace sharedWorkspace] iconForFile:srcFile];
+                    NSImage *icon = [[NSWorkspace sharedWorkspace] iconForFile:self.srcFile];
                     // make it big
                     [icon setSize:NSMakeSize(128,128)];
                     
@@ -7361,13 +7359,13 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                 {
                     [self LoadBioradPic];
                 }
-                else if( [DicomFile isFVTiffFile:srcFile])
+                else if( [DicomFile isFVTiffFile:self.srcFile])
                 {
                     [self LoadFVTiff];
                 }
 #ifndef DECOMPRESS_APP
                 else if( (( [extension isEqualToString:@"hdr"]) &&
-                          ([[NSFileManager defaultManager] fileExistsAtPath:[[srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]] == YES)) ||
+                          ([[NSFileManager defaultManager] fileExistsAtPath:[[self.srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]] == YES)) ||
                         ( [extension isEqualToString:@"nii"]))
                 {
                     // NIfTI support developed by Zack Mahdavi at the Center for Neurological Imaging, a division of Harvard Medical School
@@ -7379,7 +7377,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                     NSData			*fileData;
                     BOOL			swapByteOrder = NO;
                     
-                    NIfTI = (nifti_1_header *) nifti_read_header([srcFile UTF8String], nil, 0);
+                    NIfTI = (nifti_1_header *) nifti_read_header([self.srcFile UTF8String], nil, 0);
                     
                     // Verify that this file should be treated as a NIfTI file.  If magic is not set to anything, we must assume it is analyze.
                     if( (NIfTI->magic[0] == 'n')                           &&
@@ -7403,7 +7401,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                         short sform_code = NIfTI->sform_code;
                         
                         // Read img file or read nii file after vox_offset
-                        nifti_imagedata = nifti_image_read([srcFile UTF8String], 1);
+                        nifti_imagedata = nifti_image_read([self.srcFile UTF8String], 1);
                         
                         if( (NIfTI->magic[0] == 'n')    &&
                            (NIfTI->magic[1] == 'i')	&&
@@ -7411,7 +7409,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                            (NIfTI->magic[3] == '\0'))
                         {
                             // This is a "two file" nifti file.  Image file is separated from header.
-                            fileData = [[NSData alloc] initWithContentsOfFile: [[srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]];
+                            fileData = [[NSData alloc] initWithContentsOfFile: [[self.srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]];
                         }
                         else
                         {
@@ -7795,9 +7793,9 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                     }
                     else if( [extension isEqualToString:@"hdr"]) // 'old' ANALYZE
                     {
-                        if ([[NSFileManager defaultManager] fileExistsAtPath:[[srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]] == YES)
+                        if ([[NSFileManager defaultManager] fileExistsAtPath:[[self.srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]] == YES)
                         {
-                            NSData		*file = [NSData dataWithContentsOfFile: srcFile];
+                            NSData		*file = [NSData dataWithContentsOfFile: self.srcFile];
                             
                             if( [file length] == 348)
                             {
@@ -7837,7 +7835,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                                 totSize = height * width * 2;
                                 oImage = malloc( totSize);
                                 
-                                fileData = [[NSData alloc] initWithContentsOfFile: [[srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]];
+                                fileData = [[NSData alloc] initWithContentsOfFile: [[self.srcFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"img"]];
                                 
                                 short datatype = Analyze->dime.datatype;
                                 if( swapByteOrder) datatype = Endian16_Swap( datatype);
@@ -7977,7 +7975,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                         [extension isEqualToString:@"png"] ||
                         [extension isEqualToString:@"gif"])
                 {
-                    otherImage = [[NSImage alloc] initWithContentsOfFile: srcFile];
+                    otherImage = [[NSImage alloc] initWithContentsOfFile: self.srcFile];
                 }
             
                 else if( [extension isEqualToString:@"tiff"] ||
@@ -7986,7 +7984,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                 {
 #ifndef STATIC_DICOM_LIB
                     
-                    TIFF* tif = TIFFOpen([srcFile UTF8String], "r");
+                    TIFF* tif = TIFFOpen([self.srcFile UTF8String], "r");
                     if( tif)
                     {
                         short   bpp, count, tifspp;
@@ -8011,7 +8009,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
 #endif
                     if( USECUSTOMTIFF == NO)
                     {
-                        otherImage = [[NSImage alloc] initWithContentsOfFile: srcFile];
+                        otherImage = [[NSImage alloc] initWithContentsOfFile: self.srcFile];
                     }
                 }
             
@@ -8050,7 +8048,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
                    [extension isEqualToString:@"avi"])
                 {
                     NSError *error = nil;
-                    AVAsset *asset = [AVAsset assetWithURL: [NSURL fileURLWithPath: srcFile]];
+                    AVAsset *asset = [AVAsset assetWithURL: [NSURL fileURLWithPath: self.srcFile]];
                     AVAssetReader *asset_reader = [[[AVAssetReader alloc] initWithAsset: asset error: &error] autorelease];
                     
                     NSArray* video_tracks = [asset tracksWithMediaType: AVMediaTypeVideo];
@@ -8131,7 +8129,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
         
         if( fImage == nil)
         {
-            NSLog(@"not able to load the image : %@", srcFile);
+            NSLog(@"not able to load the image : %@", self.srcFile);
             
             if( fExternalOwnedImage)
                 fImage = fExternalOwnedImage;
@@ -8185,7 +8183,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
         {
             NSLog( @"CheckLoad Exception");
             NSLog( @"Exception : %@", [ne description]);
-            NSLog( @"Exception for this file: %@", srcFile);
+            NSLog( @"Exception for this file: %@", self.srcFile);
         }
         @finally {
             [checking unlock];
@@ -8211,7 +8209,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
         {
             NSLog( @"CheckLoad Exception");
             NSLog( @"Exception : %@", [ne description]);
-            NSLog( @"Exception for this file: %@", srcFile);
+            NSLog( @"Exception for this file: %@", self.srcFile);
         }
         @finally {
             [checking unlock];
@@ -9042,15 +9040,12 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     needToCompute8bitRepresentation = YES;
 }
 
-- (void)setSourceFile:(NSString*)s
-{
-    [srcFile release];
-    srcFile = [s retain];
+- (void)setSourceFile:(NSString *)s {
+    self.srcFile = s;
 }
 
--(NSString*) sourceFile
-{
-    return srcFile;
+- (NSString *)sourceFile {
+    return self.srcFile;
 }
 
 - (void) ConvertToBW:(long) mode
@@ -10433,12 +10428,12 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     {
         if( self.dcmtkDcmFileFormat)
         {
-            NSMutableDictionary *dic = [cachedDCMTKFileFormat objectForKey: srcFile];
+            NSMutableDictionary *dic = [cachedDCMTKFileFormat objectForKey: self.srcFile];
             
             [dic setValue: [NSNumber numberWithInt: [[dic objectForKey: @"count"] intValue]-1] forKey: @"count"];
             
             if( [[dic objectForKey: @"count"] intValue] == 0)
-                [cachedDCMTKFileFormat removeObjectForKey: srcFile];
+                [cachedDCMTKFileFormat removeObjectForKey: self.srcFile];
             
             self.dcmtkDcmFileFormat = nil;
         }
@@ -10520,7 +10515,9 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     [self clearCachedPapyGroups];
     [self clearCachedDCMFrameworkFiles];
     
-    [srcFile release];
+    [_srcFile release];
+    _srcFile = nil;
+    
     [checking unlock];
     [checking release];
     checking = nil;
@@ -10610,7 +10607,7 @@ void erase_outside_circle(char *buf, int width, int height, int cx, int cy, int 
     NSMutableString *description = [NSMutableString string];
     [description appendString:NSStringFromClass([self class])];
     [description appendString:[NSString stringWithFormat:@" <%lx>", (unsigned long) self]];
-    [description appendString:[NSString stringWithFormat: @" source File: %@\n", srcFile]];
+    [description appendString:[NSString stringWithFormat: @" source File: %@\n", self.srcFile]];
     [description appendString:[NSString stringWithFormat: @"core Data Image ID: %@\n", imageObjectID]];
     [description appendString:[NSString stringWithFormat: @"width: %d\n", (int) width]];
     [description appendString:[NSString stringWithFormat: @"height: %d\n", (int) height]];

--- a/Horos/Sources/DCMView.h
+++ b/Horos/Sources/DCMView.h
@@ -172,7 +172,7 @@ typedef enum {DCMViewTextAlignLeft, DCMViewTextAlignCenter, DCMViewTextAlignRigh
     NSMutableArray  *dcmPixList;
     NSArray			*dcmFilesList;
 	NSMutableArray  *dcmRoiList, *curRoiList;
-    DCMPix			*curDCM;
+    DCMPix			*_curDCM;
 	DCMExportPlugin	*dcmExportPlugin;
 	
     char            listType;
@@ -370,7 +370,7 @@ typedef enum {DCMViewTextAlignLeft, DCMViewTextAlignCenter, DCMViewTextAlignRigh
 @property(nonatomic) float scaleValue, rotation;
 @property(nonatomic) NSPoint origin;
 @property(readonly) double pixelSpacing, pixelSpacingX, pixelSpacingY;
-@property(readonly) DCMPix *curDCM;
+@property(readonly, strong) DCMPix *curDCM;
 @property(retain) DCMExportPlugin *dcmExportPlugin;
 @property(readonly) float mouseXPos, mouseYPos;
 @property(readonly) float contextualMenuInWindowPosX, contextualMenuInWindowPosY;

--- a/Horos/Sources/DicomDatabase.mm
+++ b/Horos/Sources/DicomDatabase.mm
@@ -643,7 +643,7 @@ static DicomDatabase* activeLocalDatabase = nil;
     return _name? _name : [NSString stringWithFormat:NSLocalizedString(@"Local Database (%@)", nil), self.baseDirPath];
 }
 
--(NSManagedObjectContext*)contextAtPath:(NSString*)sqlFilePath {
+- (NSManagedObjectContext *)contextAtPath:(NSString *)sqlFilePath {
     // custom migration
     
     NSManagedObjectContext* context = nil;
@@ -651,7 +651,7 @@ static DicomDatabase* activeLocalDatabase = nil;
     BOOL rebuildPatientUIDs = NO;
     BOOL independentContext = YES;
     
-    if (!self.managedObjectContext)
+    if (!self.managedObjectContext || ![sqlFilePath isEqualToString:self.managedObjectContext.persistentStoreCoordinator.persistentStores.firstObject.URL.path])
         independentContext = NO;
     
     if( independentContext == NO) // avoid doing this for independent contexts: we know it's already ok, and this leads to very bad crashes

--- a/Horos/Sources/DicomImage.h
+++ b/Horos/Sources/DicomImage.h
@@ -53,7 +53,7 @@ void* sopInstanceUIDEncode( NSString *sopuid);
 
 @interface DicomImage : NSManagedObject
 {
-	NSString	*completePathCache;
+	NSString *_completePathCache;
 	
 	NSString	*sopInstanceUID;
 	NSNumber	*inDatabaseFolder;

--- a/Horos/Sources/EndoscopyMPRView.m
+++ b/Horos/Sources/EndoscopyMPRView.m
@@ -77,8 +77,8 @@
 	[super subDrawRect:aRect];
 	
 	float xCrossCenter,yCrossCenter;
-	xCrossCenter = (crossPositionX-[[self curDCM] pwidth]/2) * scaleValue;
-	yCrossCenter = (crossPositionY-[[self curDCM] pheight]/2) * scaleValue;
+	xCrossCenter = (crossPositionX-[self.curDCM pwidth]/2) * scaleValue;
+	yCrossCenter = (crossPositionY-[self.curDCM pheight]/2) * scaleValue;
 		
 	// normalization of FOCAL VECTOR
 	float vectNorm = sqrt(pow(focalShiftX,2)+pow(focalShiftY/[self pixelSpacingX]*[self pixelSpacingY],2));
@@ -99,7 +99,7 @@
 	glScalef (2.0f /(xFlipped ? -(drawingFrameRect.size.width) : drawingFrameRect.size.width), -2.0f / (yFlipped ? -(drawingFrameRect.size.height) : drawingFrameRect.size.height), 1.0f); // scale to port per pixel scale
 	glRotatef (rotation, 0.0f, 0.0f, 1.0f); // rotate matrix for image rotation
 	glTranslatef( origin.x, -origin.y, 0.0f);
-	glScalef( 1.f, curDCM.pixelRatio, 1.f);
+	glScalef( 1.f, self.curDCM.pixelRatio, 1.f);
 	
 	// antialiasing
 	glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
@@ -165,8 +165,8 @@
 		for(i=0;i<[flyThroughPath count];i++)
 		{
 			Point3D* pt = [flyThroughPath objectAtIndex:i];
-			float x = (pt.x-[[self curDCM] pwidth]/2) * scaleValue;
-			float y = (pt.y-[[self curDCM] pheight]/2) * scaleValue ; //* [self pixelSpacingY]/[self pixelSpacingX];
+			float x = (pt.x-[self.curDCM pwidth]/2) * scaleValue;
+			float y = (pt.y-[self.curDCM pheight]/2) * scaleValue ; //* [self pixelSpacingY]/[self pixelSpacingX];
 			glVertex2f(x,y);
 		}
 	
@@ -368,7 +368,7 @@
 //	[[self controller] reslice: (long)x+0.5:  (long)y+0.5: self];
 //	[self setCrossPositionX: (float)x];
 //	[self setCrossPositionY: (float)y];
-//	[self setCrossPosition:x+[[self curDCM] pwidth]/2 :y+[[self curDCM] pwidth]/2];
+//	[self setCrossPosition:x+[self.curDCM pwidth]/2 :y+[self.curDCM pwidth]/2];
 }
 
 - (NSPoint) cameraPosition
@@ -545,7 +545,7 @@
 {
 	if ([sender isEqual:[[self window] windowController]])
 	{
-		DCMPix *curPix = [self curDCM];
+		DCMPix *curPix = self.curDCM;
 
 		long	annotCopy		= [[NSUserDefaults standardUserDefaults] integerForKey: @"ANNOTATIONS"],
 				clutBarsCopy	= [[NSUserDefaults standardUserDefaults] integerForKey: @"CLUTBARS"];

--- a/Horos/Sources/MPRController.m
+++ b/Horos/Sources/MPRController.m
@@ -79,12 +79,14 @@ static float deg2rad = M_PI/180.0;
 	return ((atan2( sc[1], sc[0])) / deg2rad);
 }
 
-- (DCMPix*) emptyPix: (DCMPix*) oP width: (long) w height: (long) h
+- (DCMPix *)emptyPix:(DCMPix *)oP width:(long)w height:(long)h
 {
-	long size = sizeof( float) * w * h;
-	float *imagePtr = malloc( size);
-	DCMPix *emptyPix = [[DCMPix alloc] initWithData: imagePtr :32 :w :h :[oP pixelSpacingX] :[oP pixelSpacingY] :[oP originX] :[oP originY] :[oP originZ]];
-	free( imagePtr);
+	size_t size = sizeof(float) * w * h;
+    float *imagePtr = malloc(size);
+    
+	DCMPix *emptyPix = [[DCMPix alloc] initWithData:imagePtr :32 :w :h :[oP pixelSpacingX] :[oP pixelSpacingY] :[oP originX] :[oP originY] :[oP originZ]];
+	
+    free(imagePtr);
 	
 	[emptyPix setImageObjectID: [oP imageObjectID]];
 	emptyPix.srcFile = oP.srcFile;

--- a/Horos/Sources/MPRDCMView.m
+++ b/Horos/Sources/MPRDCMView.m
@@ -567,7 +567,7 @@ unsigned int minimumStep;
             [vrView renderBlendedVolume];
             
             float *blendedImagePtr = nil;
-            DCMPix *bPix = [blendingView curDCM];
+            DCMPix *bPix = blendingView.curDCM;
             
             if( moveCenter)
             {
@@ -919,10 +919,10 @@ unsigned int minimumStep;
 			
 			glPointSize( 10 * self.window.backingScaleFactor);
 			glBegin( GL_POINTS);
-			sc[0] = sc[ 0] / curDCM.pixelSpacingX;
-			sc[1] = sc[ 1] / curDCM.pixelSpacingY;
-			sc[0] -= curDCM.pwidth * 0.5f;
-			sc[1] -= curDCM.pheight * 0.5f;
+			sc[0] = sc[ 0] / self.curDCM.pixelSpacingX;
+			sc[1] = sc[ 1] / self.curDCM.pixelSpacingY;
+			sc[0] -= self.curDCM.pwidth * 0.5f;
+			sc[1] -= self.curDCM.pheight * 0.5f;
 			glVertex2f( scaleValue*sc[ 0], scaleValue*sc[ 1]);
 			glEnd();
 
@@ -938,10 +938,10 @@ unsigned int minimumStep;
 			
 			glPointSize( 10 * self.window.backingScaleFactor);
 			glBegin( GL_POINTS);
-			sc[0] = sc[ 0] / curDCM.pixelSpacingX;
-			sc[1] = sc[ 1] / curDCM.pixelSpacingY;
-			sc[0] -= curDCM.pwidth * 0.5f;
-			sc[1] -= curDCM.pheight * 0.5f;
+			sc[0] = sc[ 0] / self.curDCM.pixelSpacingX;
+			sc[1] = sc[ 1] / self.curDCM.pixelSpacingY;
+			sc[0] -= self.curDCM.pwidth * 0.5f;
+			sc[1] -= self.curDCM.pheight * 0.5f;
 			glVertex2f( scaleValue*sc[ 0], scaleValue*sc[ 1]);
 			glEnd();
 
@@ -957,10 +957,10 @@ unsigned int minimumStep;
 			
 			glPointSize( 10 * self.window.backingScaleFactor);
 			glBegin( GL_POINTS);
-			sc[0] = sc[ 0] / curDCM.pixelSpacingX;
-			sc[1] = sc[ 1] / curDCM.pixelSpacingY;
-			sc[0] -= curDCM.pwidth * 0.5f;
-			sc[1] -= curDCM.pheight * 0.5f;
+			sc[0] = sc[ 0] / self.curDCM.pixelSpacingX;
+			sc[1] = sc[ 1] / self.curDCM.pixelSpacingY;
+			sc[0] -= self.curDCM.pwidth * 0.5f;
+			sc[1] -= self.curDCM.pheight * 0.5f;
 			glVertex2f( scaleValue*sc[ 0], scaleValue*sc[ 1]);
 			glEnd();
 		}
@@ -1356,7 +1356,7 @@ unsigned int minimumStep;
 	if( LOD == 0)
 		return 0;
 	
-	if( curDCM.pixelSpacingX == 0)
+	if( self.curDCM.pixelSpacingX == 0)
 		return 0;
 	
 	// Intersection of the lines
@@ -1366,10 +1366,10 @@ unsigned int minimumStep;
 	{
 		mouseLocation = [self ConvertFromNSView2GL: mouseLocation];
 		
-		mouseLocation.x *= curDCM.pixelSpacingX;
-		mouseLocation.y *= curDCM.pixelSpacingY;
+		mouseLocation.x *= self.curDCM.pixelSpacingX;
+		mouseLocation.y *= self.curDCM.pixelSpacingY;
 		
-		float f = curDCM.pixelSpacingX / LOD * self.window.backingScaleFactor;
+		float f = self.curDCM.pixelSpacingX / LOD * self.window.backingScaleFactor;
 		
 		if( mouseLocation.x > r.x - BS * f && mouseLocation.x < r.x + BS* f && mouseLocation.y > r.y - BS* f && mouseLocation.y < r.y + BS* f)
 		{
@@ -1384,7 +1384,7 @@ unsigned int minimumStep;
                 NSPoint a1 = NSMakePoint( crossLinesA[ 0][ 0], crossLinesA[ 0][ 1]);
                 NSPoint a2 = NSMakePoint( crossLinesA[ 1][ 0], crossLinesA[ 1][ 1]);
                 [DCMView DistancePointLine:mouseLocation :a1 :a2 :&distance1];
-                distance1 /= curDCM.pixelSpacingX;
+                distance1 /= self.curDCM.pixelSpacingX;
             }
             
             if( crossLinesB[ 0][ 0] != HUGE_VALF)
@@ -1393,7 +1393,7 @@ unsigned int minimumStep;
                 NSPoint b2 = NSMakePoint( crossLinesB[ 1][ 0], crossLinesB[ 1][ 1]);
                 
                 [DCMView DistancePointLine:mouseLocation :b1 :b2 :&distance2];
-                distance2 /= curDCM.pixelSpacingX;
+                distance2 /= self.curDCM.pixelSpacingX;
 			}
             
 			if( distance1 * scaleValue < 10*self.window.backingScaleFactor || distance2 * scaleValue < 10*self.window.backingScaleFactor)
@@ -1606,7 +1606,7 @@ unsigned int minimumStep;
 			rotateLines = YES;
 			
 			NSPoint mouseLocation = [self ConvertFromNSView2GL: [self convertPoint: [theEvent locationInWindow] fromView: nil]];
-			mouseLocation.x *= curDCM.pixelSpacingX;	mouseLocation.y *= curDCM.pixelSpacingY;
+			mouseLocation.x *= self.curDCM.pixelSpacingX;	mouseLocation.y *= self.curDCM.pixelSpacingY;
 			rotateLinesStartAngle = [self angleBetween: mouseLocation center: [self centerLines]] - angleMPR;
 			
 			[self mouseDragged: theEvent];
@@ -1810,7 +1810,7 @@ unsigned int minimumStep;
 		windowController.lowLOD = YES;
 		
 		NSPoint mouseLocation = [self ConvertFromNSView2GL: [self convertPoint: [theEvent locationInWindow] fromView: nil]];
-		mouseLocation.x *= curDCM.pixelSpacingX;	mouseLocation.y *= curDCM.pixelSpacingY;
+		mouseLocation.x *= self.curDCM.pixelSpacingX;	mouseLocation.y *= self.curDCM.pixelSpacingY;
 		angleMPR = [self angleBetween: mouseLocation center: [self centerLines]];
 		
 		angleMPR -= rotateLinesStartAngle;
@@ -1986,7 +1986,7 @@ unsigned int minimumStep;
     
     pixToDicomTransform = [self pixToDicomTransform];
     
-    plane.point = N3VectorApplyTransform(N3VectorMake((CGFloat)curDCM.pwidth/2.0, (CGFloat)curDCM.pheight/2.0, 0.0), pixToDicomTransform);
+    plane.point = N3VectorApplyTransform(N3VectorMake((CGFloat)self.curDCM.pwidth/2.0, (CGFloat)self.curDCM.pheight/2.0, 0.0), pixToDicomTransform);
     plane.normal = N3VectorNormalize(N3VectorApplyTransformToDirectionalVector(N3VectorMake(0.0, 0.0, 1.0), pixToDicomTransform));
     
 	if (N3PlaneIsValid(plane)) {

--- a/Horos/Sources/OrthogonalMPRView.m
+++ b/Horos/Sources/OrthogonalMPRView.m
@@ -313,11 +313,11 @@
 
 - (void) convertPixX: (float) x pixY: (float) y toDICOMCoords: (float*) location 
 {
-    if( curDCM.stack > 1) {
+    if( self.curDCM.stack > 1) {
         long stackImageIndex;
         
-        if(flippedData) stackImageIndex = curImage-(curDCM.stack-1)/2;
-        else stackImageIndex = curImage+(curDCM.stack-1)/2;
+        if(flippedData) stackImageIndex = curImage-(self.curDCM.stack-1)/2;
+        else stackImageIndex = curImage+(self.curDCM.stack-1)/2;
         
         if( stackImageIndex < 0) stackImageIndex = 0;
         if( stackImageIndex >= [dcmPixList count]) stackImageIndex = (long)[dcmPixList count]-1;
@@ -325,7 +325,7 @@
         [[dcmPixList objectAtIndex: stackImageIndex] convertPixX: x pixY: y toDICOMCoords: location pixelCenter: YES];
     }
     else {
-        [curDCM convertPixX: x pixY: y toDICOMCoords: location pixelCenter: YES];
+        [self.curDCM convertPixX: x pixY: y toDICOMCoords: location pixelCenter: YES];
     }
 }
 
@@ -357,7 +357,7 @@
 	if(crossPositionX == x)
 		return ;
 	x = (x<0)? 0 : x;
-	x = (x>=[[self curDCM] pwidth])? [[self curDCM] pwidth]-1 : x;
+	x = (x>=[self.curDCM pwidth])? [self.curDCM pwidth]-1 : x;
 	crossPositionX = x;
 }
 
@@ -366,7 +366,7 @@
 	if(crossPositionY == y)
 		return;
 	y = (y<0)? 0 : y;
-	y = (y>=[[self curDCM] pheight])? [[self curDCM] pheight]-1 : y;
+	y = (y>=[self.curDCM pheight])? [self.curDCM pheight]-1 : y;
 	crossPositionY = y;
 }
 
@@ -383,10 +383,10 @@
 
 - (void) adjustWLWW:(float) wl :(float) ww
 {
-	[curDCM changeWLWW :wl : ww];
+	[self.curDCM changeWLWW :wl : ww];
     
-    curWW = [curDCM ww];
-    curWL = [curDCM wl];
+    curWW = [self.curDCM ww];
+    curWL = [self.curDCM wl];
 	
 	[self loadTextures];
     [self setNeedsDisplay:YES];
@@ -394,11 +394,11 @@
 
 - (void) getWLWW:(float*) wl :(float*) ww
 {
-	if( curDCM == nil) NSLog(@"OrthogonalMPRView getWLWW : curDCM nil");
+	if( self.curDCM == nil) NSLog(@"OrthogonalMPRView getWLWW : curDCM nil");
 	else
 	{
-		if(wl) *wl = [curDCM wl];
-		if(ww) *ww = [curDCM ww];
+		if(wl) *wl = [self.curDCM wl];
+		if(ww) *ww = [self.curDCM ww];
 	}
 }
 
@@ -454,16 +454,16 @@
 		glEnable(GL_POLYGON_SMOOTH);
 	
 		float xCrossCenter,yCrossCenter;
-		xCrossCenter = (crossPositionX  - [[self curDCM] pwidth]/2) * scaleValue;
-		yCrossCenter = (crossPositionY  - [[self curDCM] pheight]/2) * scaleValue;
+		xCrossCenter = (crossPositionX  - [self.curDCM pwidth]/2) * scaleValue;
+		yCrossCenter = (crossPositionY  - [self.curDCM pheight]/2) * scaleValue;
 		
-		//NSLog(@"subdraw thickslab:%f pixelSpacingY:%f", [controller thickSlabDistance], [[self curDCM] pixelSpacingY]);
+		//NSLog(@"subdraw thickslab:%f pixelSpacingY:%f", [controller thickSlabDistance], [self.curDCM pixelSpacingY]);
 		//yCrossCenter = yCrossCenter - ([controller thickSlabDistance]*(float)[controller thickSlab]   / 2.0);
 		
 	//	NSRect size = [self frame];
 	//	float viewportSizeX, viewportSizeY;
 	//	viewportSizeX = size.size.width;
-	//	viewportSizeY = size.size.height / [curDCM pixelRatio];
+	//	viewportSizeY = size.size.height / [self.curDCM pixelRatio];
 
 	//	float xAxeLength, yAxeLength;
 	//	xAxeLength = viewportSizeX;
@@ -474,16 +474,16 @@
 		glBegin(GL_LINES);
 		// vertical axis
 		glVertex2f(xCrossCenter,-4000);
-		glVertex2f(xCrossCenter,yCrossCenter -50.0/curDCM.pixelRatio);
+		glVertex2f(xCrossCenter,yCrossCenter -50.0/self.curDCM.pixelRatio);
 	
 		if (displayResliceAxes == 2)
 		{
-			glVertex2f(xCrossCenter,yCrossCenter -10.0/curDCM.pixelRatio);
-			glVertex2f(xCrossCenter,yCrossCenter +10.0/curDCM.pixelRatio);
+			glVertex2f(xCrossCenter,yCrossCenter -10.0/self.curDCM.pixelRatio);
+			glVertex2f(xCrossCenter,yCrossCenter +10.0/self.curDCM.pixelRatio);
 		}
 		
 		glColor3f (0.0f, 1.0f, 0.0f);
-		glVertex2f(xCrossCenter,yCrossCenter +50.0/curDCM.pixelRatio);
+		glVertex2f(xCrossCenter,yCrossCenter +50.0/self.curDCM.pixelRatio);
 		glVertex2f(xCrossCenter,4000);
 		
 		// horizontal axis
@@ -506,15 +506,15 @@
 			shift =  (float)thickSlabX / 2.0 * scaleValue;
 			glColor3f (0.0f, 0.0f, 1.0f);
 			glVertex2f(xCrossCenter-shift,-4000);
-			glVertex2f(xCrossCenter-shift,yCrossCenter -50.0/curDCM.pixelRatio);
+			glVertex2f(xCrossCenter-shift,yCrossCenter -50.0/self.curDCM.pixelRatio);
 			
-			glVertex2f(xCrossCenter-shift,yCrossCenter +50.0/curDCM.pixelRatio);
+			glVertex2f(xCrossCenter-shift,yCrossCenter +50.0/self.curDCM.pixelRatio);
 			glVertex2f(xCrossCenter-shift,4000);
 			
 			glVertex2f(xCrossCenter+shift,-4000);
-			glVertex2f(xCrossCenter+shift,yCrossCenter -50.0/curDCM.pixelRatio);
+			glVertex2f(xCrossCenter+shift,yCrossCenter -50.0/self.curDCM.pixelRatio);
 			
-			glVertex2f(xCrossCenter+shift,yCrossCenter +50.0/curDCM.pixelRatio);
+			glVertex2f(xCrossCenter+shift,yCrossCenter +50.0/self.curDCM.pixelRatio);
 			glVertex2f(xCrossCenter+shift,4000);
 		}
 		
@@ -1088,7 +1088,7 @@
 - (void)mouseDraggedBlending:(NSEvent *)event{
 	[super mouseDraggedBlending:event];
 	[self setWLWW: curWL :curWW];
-	[blendingView setWLWW:[[blendingView curDCM] wl] :[[blendingView curDCM] ww]];
+	[blendingView setWLWW:[blendingView.curDCM wl] :[blendingView.curDCM ww]];
 }
 
 
@@ -1147,26 +1147,26 @@
 				break;
 			}
 			
-			[curDCM changeWLWW :eWL  :eWW];
+			[self.curDCM changeWLWW :eWL  :eWW];
 		}
 		else
 		{
-			[curDCM changeWLWW : startWL + (current.y -  start.y)*WWAdapter :startWW + (current.x -  start.x)*WWAdapter];
+			[self.curDCM changeWLWW : startWL + (current.y -  start.y)*WWAdapter :startWW + (current.x -  start.x)*WWAdapter];
 		}
 		
-		curWW = [curDCM ww];
-		curWL = [curDCM wl];
+		curWW = [self.curDCM ww];
+		curWL = [self.curDCM wl];
 		
 		if( [self is2DViewer] == YES)
-			[[self windowController] setCurWLWWMenu: [DCMView findWLWWPreset: curWL :curWW :curDCM]];
+			[[self windowController] setCurWLWWMenu: [DCMView findWLWWPreset: curWL :curWW :self.curDCM]];
 		
 		// change Window level
 		[self setWLWW: curWL :curWW];
 
 		
-		[[NSNotificationCenter defaultCenter] postNotificationName: OsirixChangeWLWWNotification object: curDCM userInfo:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationName: OsirixChangeWLWWNotification object: self.curDCM userInfo:nil];
 		
-		if( [curDCM SUVConverted] == NO)
+		if( [self.curDCM SUVConverted] == NO)
 		{
 			//set value for Series Object Presentation State
 			[[self seriesObj] setValue:[NSNumber numberWithFloat:curWW] forKey:@"windowWidth"];

--- a/Horos/Sources/ROIVolume.mm
+++ b/Horos/Sources/ROIVolume.mm
@@ -115,12 +115,12 @@
 		{
 			[roiList addObject:curROI];
 			// volume
-			DCMPix *curDCM = [curROI pix];
+			DCMPix *pic = [curROI pix];
 			float curArea = [curROI roiArea];
 			if( preLocation != 0)
-				volume += (([curDCM sliceLocation] - preLocation)/10.) * (curArea + prevArea)/2.;
+				volume += (([pic sliceLocation] - preLocation)/10.) * (curArea + prevArea)/2.;
 			prevArea = curArea;
-			preLocation = [curDCM sliceLocation];
+			preLocation = [pic sliceLocation];
 		}
 	}
 	

--- a/Horos/Sources/RemoteDicomDatabase.mm
+++ b/Horos/Sources/RemoteDicomDatabase.mm
@@ -65,7 +65,17 @@
 
 @end
 
+@interface RemoteDicomDatabaseManagedObjectContext : N2ManagedObjectContext
+
+@property BOOL cleanOnDealloc;
+
+@end
+
 @implementation RemoteDicomDatabase
+
+- (Class)NSManagedObjectContextClass {
+    return RemoteDicomDatabaseManagedObjectContext.class;
+}
 
 +(RemoteDicomDatabase*)databaseForLocation:(NSString*)location port:(NSUInteger)port name:(NSString*)name update:(BOOL)flagUpdate {
 	NSHost* host;
@@ -367,15 +377,15 @@
 	[thread enterOperation];
 	thread.status = NSLocalizedString(@"Transferring database index...", nil);
 	
-	NSString* path = [NSFileManager.defaultManager tmpFilePathInDir:self.baseDirPath];
-	NSOutputStream* fileStream = [NSOutputStream outputStreamToFileAtPath:path append:NO];
+	NSString *path = [NSFileManager.defaultManager tmpFilePathInDir:self.baseDirPath];
+	NSOutputStream *fileStream = [NSOutputStream outputStreamToFileAtPath:path append:NO];
 	[fileStream open];
 	
 	NSData* request = [NSMutableData dataWithBytes:"DATAB" length:6];
 	NSArray* context = [NSArray arrayWithObjects: thread, [NSNumber numberWithUnsignedInteger:databaseIndexSize], fileStream, [N2MutableUInteger mutableUIntegerWithUInteger:0], nil];
 	[self synchronousRequest:request urgent:YES dataHandlerTarget:self selector:@selector(_connection:handleData_fetchDatabaseIndex:context:) context:context];
 	
-	[fileStream close];
+    [fileStream close];
 	[thread exitOperation];
 	
 	if (thread.isCancelled)
@@ -428,11 +438,17 @@
 	return [RemoteDicomDatabase fetchDicomDestinationInfoForAddress:self.address port:self.port];
 }
 
--(void)updateOnMainThread: (NSString*) path
+- (void)updateOnMainThread:(NSString *)path
 {
     [_updateLock lock];
 
-    NSManagedObjectContext* context = [self contextAtPath:path];
+    NSManagedObjectContext *context = [self contextAtPath:path];
+    
+    NSFetchRequest *f = [NSFetchRequest fetchRequestWithEntityName:@"Study"];
+    f.predicate = [NSPredicate predicateWithValue:YES];
+    
+    NSError *err = nil;
+    NSArray *studies = [context executeFetchRequest:f error:&err];
     
     NSPersistentStoreCoordinator *cc = context.persistentStoreCoordinator;
     NSPersistentStoreCoordinator *c = self.managedObjectContext.persistentStoreCoordinator;
@@ -447,10 +463,10 @@
         
         [_sqlFileName release];
         _sqlFileName = [[path lastPathComponent] retain];
-        NSString* oldSqlFilePath = [_sqlFilePath autorelease];
+        /*NSString* oldSqlFilePath =*/ [_sqlFilePath autorelease];
         _sqlFilePath = [path retain];
         
-        NSManagedObjectContext *previousContext = self.managedObjectContext;
+        RemoteDicomDatabaseManagedObjectContext *previousContext = (id)self.managedObjectContext;
         [[previousContext retain] autorelease];
         
         [[BrowserController currentBrowser] willChangeContext];
@@ -461,8 +477,8 @@
         [[NSNotificationCenter defaultCenter] postNotificationName:_O2AddToDBAnywayNotification object:self];
         [[NSNotificationCenter defaultCenter] postNotificationName:OsirixDicomDatabaseDidChangeContextNotification object:self];
         
-        // delete old index file
-        [NSFileManager.defaultManager removeItemAtPath:oldSqlFilePath error:NULL];
+        // delete old index file(s)
+        previousContext.cleanOnDealloc = YES;
         
         if (!_updateTimer) {
             _updateTimer = [NSTimer timerWithTimeInterval:[[NSUserDefaults standardUserDefaults] integerForKey:@"DatabaseRefreshInterval"] target:[RemoteDicomDatabase class] selector:@selector(_updateTimerCallbackClass:) userInfo:[NSValue valueWithPointer:self] repeats:YES];
@@ -494,7 +510,7 @@
 		
 		_timestamp = [self fetchDatabaseTimestamp];
 		
-		[self performSelectorOnMainThread: @selector( updateOnMainThread:) withObject: path waitUntilDone: NO];
+        [self performSelectorOnMainThread:@selector(updateOnMainThread:) withObject:path waitUntilDone:NO];
 		
 	} @catch (NSException* e) {
 		@throw;
@@ -915,6 +931,25 @@ enum RemoteDicomDatabaseStudiesAlbumAction { RemoteDicomDatabaseStudiesAlbumActi
 }
 
 -(void)addDefaultAlbums { // do nothing
+}
+
+@end
+
+
+@implementation RemoteDicomDatabaseManagedObjectContext
+
+- (void)dealloc {
+//    [NSFileManager.defaultManager removeItemAtPath:oldSqlFilePath error:NULL]
+    
+#warning TODO: clean up old indexes, but be careful not to do this before other threads are done
+//    if (self.cleanOnDealloc)
+//        if (NSURL *url = self.persistentStoreCoordinator.persistentStores.firstObject.URL) {
+//            NSURL *dir = [url URLByDeletingLastPathComponent];
+//            [[NSFileManager defaultManager] removeItemAtURL:url error:NULL];
+//            [[NSFileManager defaultManager] removeItemAtURL:[dir URLByAppendingPathComponent:[url.lastPathComponent stringByAppendingString:@"-shm"]] error:NULL];
+//        }
+//    
+    [super dealloc];
 }
 
 @end

--- a/Horos/Sources/ViewerController.m
+++ b/Horos/Sources/ViewerController.m
@@ -8325,7 +8325,7 @@ static int avoidReentryRefreshDatabase = 0;
                         NSLog(@"Exception change image data: %@", e);
                     }
                     
-                    DCMPix *curDCM = [imageView curDCM];
+                    DCMPix *pic = [imageView curDCM];
                     
                     [self setWindowTitle:self];
                     
@@ -8340,8 +8340,8 @@ static int avoidReentryRefreshDatabase = 0;
                     }
                     else
                     {
-                        if( [curDCM cineRate])
-                            [speedSlider setFloatValue: [curDCM cineRate]];
+                        if( [pic cineRate])
+                            [speedSlider setFloatValue: [pic cineRate]];
                         else if( [[NSUserDefaults standardUserDefaults] floatForKey: @"defaultFrameRate"])
                             [speedSlider setFloatValue: [[NSUserDefaults standardUserDefaults] floatForKey: @"defaultFrameRate"]];
                         
@@ -13939,7 +13939,7 @@ static float oldsetww, oldsetwl;
             
             for( int x = 0; x < [pixList[y] count]; x++)
             {
-                DCMPix *curDCM = [pixList[ y] objectAtIndex: x];
+                DCMPix *pic = [pixList[ y] objectAtIndex: x];
                 
                 if( [roisSeries count] > x)
                 {
@@ -13948,9 +13948,9 @@ static float oldsetww, oldsetwl;
                     for( ROI *r in roisImages)
                     {
                         //Correct the origin only if the orientation is the same
-                        r.pix = curDCM;
+                        r.pix = pic;
                         
-                        [r setOriginAndSpacing: curDCM.pixelSpacingX :curDCM.pixelSpacingY :[DCMPix originCorrectedAccordingToOrientation: curDCM]];
+                        [r setOriginAndSpacing: pic.pixelSpacingX :pic.pixelSpacingY :[DCMPix originCorrectedAccordingToOrientation: pic]];
                         
                         [[roiList[ y] objectAtIndex: x] addObject: r];
                         [imageView roiSet: r];
@@ -16612,35 +16612,35 @@ static float oldsetww, oldsetwl;
             {
                 for( x = 0; x < [pixList[ i] count]; x++)
                 {
-                    DCMPix		*curDCM = [pixList[ i] objectAtIndex:x];
+                    DCMPix		*pic = [pixList[ i] objectAtIndex:x];
                     float		vectorP[ 9], tempOrigin[ 3], tempOriginBlending[ 3];
                     NSPoint		offset;
                     
                     // Compute blended view offset
-                    [curDCM orientation: vectorP];
+                    [pic orientation: vectorP];
                     
-                    tempOrigin[ 0] = [curDCM originX] * vectorP[ 0] + [curDCM originY] * vectorP[ 1] + [curDCM originZ] * vectorP[ 2];
-                    tempOrigin[ 1] = [curDCM originX] * vectorP[ 3] + [curDCM originY] * vectorP[ 4] + [curDCM originZ] * vectorP[ 5];
-                    tempOrigin[ 2] = [curDCM originX] * vectorP[ 6] + [curDCM originY] * vectorP[ 7] + [curDCM originZ] * vectorP[ 8];
+                    tempOrigin[ 0] = [pic originX] * vectorP[ 0] + [pic originY] * vectorP[ 1] + [pic originZ] * vectorP[ 2];
+                    tempOrigin[ 1] = [pic originX] * vectorP[ 3] + [pic originY] * vectorP[ 4] + [pic originZ] * vectorP[ 5];
+                    tempOrigin[ 2] = [pic originX] * vectorP[ 6] + [pic originY] * vectorP[ 7] + [pic originZ] * vectorP[ 8];
                     
                     tempOriginBlending[ 0] = [[[blendingController imageView] curDCM] originX] * vectorP[ 0] + [[[blendingController imageView] curDCM] originY] * vectorP[ 1] + [[[blendingController imageView] curDCM] originZ] * vectorP[ 2];
                     tempOriginBlending[ 1] = [[[blendingController imageView] curDCM] originX] * vectorP[ 3] + [[[blendingController imageView] curDCM] originY] * vectorP[ 4] + [[[blendingController imageView] curDCM] originZ] * vectorP[ 5];
                     tempOriginBlending[ 2] = [[[blendingController imageView] curDCM] originX] * vectorP[ 6] + [[[blendingController imageView] curDCM] originY] * vectorP[ 7] + [[[blendingController imageView] curDCM] originZ] * vectorP[ 8];
                     
-                    [curDCM setPixelSpacingX: [[imageView curDCM] pixelSpacingX] * ([[blendingController imageView] pixelSpacingX] / [[blendingController imageView] scaleValue]) /  ([[imageView curDCM] pixelSpacingX]/[imageView scaleValue])];
-                    [curDCM setPixelSpacingY: [[imageView curDCM] pixelSpacingY] * ([[blendingController imageView] pixelSpacingY] / [[blendingController imageView] scaleValue]) / ([[imageView curDCM] pixelSpacingY]/[imageView scaleValue])];
+                    [pic setPixelSpacingX: [[imageView curDCM] pixelSpacingX] * ([[blendingController imageView] pixelSpacingX] / [[blendingController imageView] scaleValue]) /  ([[imageView curDCM] pixelSpacingX]/[imageView scaleValue])];
+                    [pic setPixelSpacingY: [[imageView curDCM] pixelSpacingY] * ([[blendingController imageView] pixelSpacingY] / [[blendingController imageView] scaleValue]) / ([[imageView curDCM] pixelSpacingY]/[imageView scaleValue])];
                     
-                    offset.x = (tempOrigin[0] + [curDCM pwidth]*[curDCM pixelSpacingX]/2. - (tempOriginBlending[ 0] + [[[blendingController imageView] curDCM] pwidth]*[[[blendingController imageView] curDCM] pixelSpacingX]/2.));
-                    offset.y = (tempOrigin[1] + [curDCM pheight]*[curDCM pixelSpacingY]/2. - (tempOriginBlending[ 1] + [[[blendingController imageView] curDCM] pheight]*[[[blendingController imageView] curDCM] pixelSpacingY]/2.));
+                    offset.x = (tempOrigin[0] + [pic pwidth]*[pic pixelSpacingX]/2. - (tempOriginBlending[ 0] + [[[blendingController imageView] curDCM] pwidth]*[[[blendingController imageView] curDCM] pixelSpacingX]/2.));
+                    offset.y = (tempOrigin[1] + [pic pheight]*[pic pixelSpacingY]/2. - (tempOriginBlending[ 1] + [[[blendingController imageView] curDCM] pheight]*[[[blendingController imageView] curDCM] pixelSpacingY]/2.));
                     
-                    o[ 0] = [curDCM originX];		o[ 1] = [curDCM originY];		o[ 2] = [curDCM originZ];
+                    o[ 0] = [pic originX];		o[ 1] = [pic originY];		o[ 2] = [pic originZ];
                     
-                    o[ 0] -= ([[blendingController imageView] origin].x*[[[blendingController imageView] curDCM] pixelSpacingX]/[[blendingController imageView] scaleValue] - [imageView origin].x*[curDCM pixelSpacingX]/[imageView scaleValue]) + offset.x;
-                    o[ 1] += ([[blendingController imageView] origin].y*[[[blendingController imageView] curDCM] pixelSpacingY]/[[blendingController imageView] scaleValue] - [imageView origin].y*[curDCM pixelSpacingY]/[imageView scaleValue]) - offset.y;
+                    o[ 0] -= ([[blendingController imageView] origin].x*[[[blendingController imageView] curDCM] pixelSpacingX]/[[blendingController imageView] scaleValue] - [imageView origin].x*[pic pixelSpacingX]/[imageView scaleValue]) + offset.x;
+                    o[ 1] += ([[blendingController imageView] origin].y*[[[blendingController imageView] curDCM] pixelSpacingY]/[[blendingController imageView] scaleValue] - [imageView origin].y*[pic pixelSpacingY]/[imageView scaleValue]) - offset.y;
                     o[ 2] += zDiff;
                     
-                    [curDCM setOrigin: o];
-                    [curDCM computeSliceLocation];
+                    [pic setOrigin: o];
+                    [pic computeSliceLocation];
                 }
             }
             
@@ -20375,7 +20375,7 @@ static float oldsetww, oldsetwl;
     
     for( int x = 0; x < [pixList[curMovieIndex] count]; x++)
     {
-        DCMPix	*curDCM = [pixList[curMovieIndex] objectAtIndex: x];
+        DCMPix	*pic = [pixList[curMovieIndex] objectAtIndex: x];
         imageCount = 0;
         
         location = x * sliceInterval;
@@ -20438,7 +20438,7 @@ static float oldsetww, oldsetwl;
                         {
                             float location[ 3];
                             
-                            [curDCM convertPixX: [[points objectAtIndex: y] x] pixY: [[points objectAtIndex: y] y] toDICOMCoords: location pixelCenter: YES];
+                            [pic convertPixX: [[points objectAtIndex: y] x] pixY: [[points objectAtIndex: y] y] toDICOMCoords: location pixelCenter: YES];
                             
                             NSArray	*pt3D = [NSArray arrayWithObjects: [NSNumber numberWithFloat: location[0]], [NSNumber numberWithFloat:location[1]], [NSNumber numberWithFloat:location[2]], nil];
                             
@@ -20535,14 +20535,14 @@ static float oldsetww, oldsetwl;
             float location[ 3];
             NSArray	*pt3D;
             NSPoint centroid;
-            DCMPix	*curDCM;
+            DCMPix	*pic;
             
             if( fROIIndex > 0) fROIIndex--;
             if( lROIIndex < (long)[pixList[curMovieIndex] count]-1) lROIIndex++;
             
-            curDCM = [pixList[curMovieIndex] objectAtIndex: fROIIndex];
+            pic = [pixList[curMovieIndex] objectAtIndex: fROIIndex];
             centroid = [fROI centroid];
-            [curDCM  convertPixX: centroid.x pixY: centroid.y toDICOMCoords: location pixelCenter: YES];
+            [pic  convertPixX: centroid.x pixY: centroid.y toDICOMCoords: location pixelCenter: YES];
             pt3D = [NSArray arrayWithObjects: [NSNumber numberWithFloat: location[0]-1], [NSNumber numberWithFloat:location[1]-1], [NSNumber numberWithFloat:location[2]], nil];
             [*pts addObject: pt3D];
             pt3D = [NSArray arrayWithObjects: [NSNumber numberWithFloat: location[0]-1], [NSNumber numberWithFloat:location[1]+1], [NSNumber numberWithFloat:location[2]], nil];
@@ -20550,9 +20550,9 @@ static float oldsetww, oldsetwl;
             pt3D = [NSArray arrayWithObjects: [NSNumber numberWithFloat: location[0]], [NSNumber numberWithFloat:location[1]], [NSNumber numberWithFloat:location[2]], nil];
             [*pts addObject: pt3D];
             
-            curDCM = [pixList[curMovieIndex] objectAtIndex: lROIIndex];
+            pic = [pixList[curMovieIndex] objectAtIndex: lROIIndex];
             centroid = [lROI centroid];
-            [curDCM  convertPixX: centroid.x pixY: centroid.y toDICOMCoords: location pixelCenter: YES];
+            [pic  convertPixX: centroid.x pixY: centroid.y toDICOMCoords: location pixelCenter: YES];
             pt3D = [NSArray arrayWithObjects: [NSNumber numberWithFloat: location[0]-1], [NSNumber numberWithFloat:location[1]-1], [NSNumber numberWithFloat:location[2]], nil];
             [*pts addObject: pt3D];
             pt3D = [NSArray arrayWithObjects: [NSNumber numberWithFloat: location[0]-1], [NSNumber numberWithFloat:location[1]+1], [NSNumber numberWithFloat:location[2]], nil];

--- a/Horos/Sources/printView.m
+++ b/Horos/Sources/printView.m
@@ -122,9 +122,9 @@
 				NSString *tempString = [[NSUserDefaults dateFormatter] stringFromDate: date];
 				string2draw = [string2draw stringByAppendingFormat:@"%@", tempString];
 			
-				DCMPix *curDCM = [[viewer pixList] objectAtIndex: 0];
+				DCMPix *pic = [[viewer pixList] objectAtIndex: 0];
 				
-				if( [curDCM acquisitionTime]) date = [NSCalendarDate dateWithTimeIntervalSinceReferenceDate: [[curDCM acquisitionTime] timeIntervalSinceReferenceDate]];
+				if( [pic acquisitionTime]) date = [NSCalendarDate dateWithTimeIntervalSinceReferenceDate: [[pic acquisitionTime] timeIntervalSinceReferenceDate]];
 				if( date && [date yearOfCommonEra] != 3000)
 				{
 					tempString = [BrowserController TimeFormat: date];

--- a/Nitrogen/Sources/N2Connection.mm
+++ b/Nitrogen/Sources/N2Connection.mm
@@ -242,11 +242,11 @@ NSString* N2ConnectionStatusDidChangeNotification = @"N2ConnectionStatusDidChang
 	[_outputBuffer setLength:0];
     _outputBufferIndex = 0;
 	
-    NSHost* host = [_address isKindOfClass:[NSHost class]]? _address : [NSHost hostWithAddressOrName:_address];
+    NSString *hostname = [_address isKindOfClass:[NSHost class]]? [_address address] : _address;
     
 	[self setStatus:N2ConnectionStatusConnecting];
     
-	[NSStream getStreamsToHost:host port:_port inputStream:&_inputStream outputStream:&_outputStream];
+	[NSStream getStreamsToHostWithName:hostname port:_port inputStream:&_inputStream outputStream:&_outputStream];
 	[_inputStream retain]; [_outputStream retain];
 	
 	[self open];

--- a/Nitrogen/Sources/N2ManagedDatabase.h
+++ b/Nitrogen/Sources/N2ManagedDatabase.h
@@ -116,10 +116,12 @@
 - (Class)NSManagedObjectContextClass;
 - (NSManagedObjectContext *)contextAtPath:(NSString *)sqlFilePath;
 
+- (BOOL)saveDatabaseModel;
+
 @end
 
 @interface N2ManagedObjectContext : NSManagedObjectContext {
-    
+    N2ManagedObjectContext *_confinementParentContext;
 	N2ManagedDatabase* _database;
 }
 

--- a/Nitrogen/Sources/N2ManagedDatabase.h
+++ b/Nitrogen/Sources/N2ManagedDatabase.h
@@ -113,7 +113,8 @@
 
 @interface N2ManagedDatabase (Protected)
 
--(NSManagedObjectContext*)contextAtPath:(NSString*)sqlFilePath;
+- (Class)NSManagedObjectContextClass;
+- (NSManagedObjectContext *)contextAtPath:(NSString *)sqlFilePath;
 
 @end
 

--- a/Nitrogen/Sources/N2ManagedDatabase.mm
+++ b/Nitrogen/Sources/N2ManagedDatabase.mm
@@ -315,7 +315,7 @@ static int gTotalN2ManagedObjectContext = 0;
     //            [self save];
             
             if ([sqlFilePath isEqualToString:self.sqlFilePath] && [NSFileManager.defaultManager fileExistsAtPath:sqlFilePath]) {
-                moc.confinementParentContext = self.managedObjectContext; // just for retain purpose
+                moc.confinementParentContext = (id)self.managedObjectContext; // just for retain purpose
                 moc.persistentStoreCoordinator = self.managedObjectContext.persistentStoreCoordinator;
             }
             

--- a/Nitrogen/Sources/SMTPClient.m
+++ b/Nitrogen/Sources/SMTPClient.m
@@ -298,7 +298,7 @@ enum {
                 [self reset];
                 
                 self.connectionStatus = ConnectionStatusConnecting;
-                [NSStream getStreamsToHost:[NSHost hostWithName:self.client.address] port:port.integerValue inputStream:&_istream outputStream:&_ostream];
+                [NSStream getStreamsToHostWithName:self.client.address port:port.integerValue inputStream:&_istream outputStream:&_ostream];
                 [_istream retain];
                 [_ostream retain];
                 [_istream setDelegate:self];


### PR DESCRIPTION
Remote database browsing fixed. The bottom line is, since 10.something CoreData started storing database entries in a file called Database.sql-WAL (the specified storage file name with -WAL appended). Remote database sharing was only transferring Database.sql, exclusively the schema. With this pull request, I disable the WAL mode so the data actually is in Database.sql, and the old database sharing works again.
However, re-enabling database sharing brought up another bug: with remote images, srcPath wasn't being retained in DCMPix, and crashed.