### PR TITLE
fix database window not coming to foreground

### DIFF
--- a/Horos/Sources/ViewerController.m
+++ b/Horos/Sources/ViewerController.m
@@ -22456,8 +22456,7 @@ static float oldsetww, oldsetwl;
     {
         [ViewerController closeAllWindows];
     }
-    else
-        [[BrowserController currentBrowser] showDatabase:self];
+    [[BrowserController currentBrowser] showDatabase:self];
 }
 
 - (void)setStandardRect:(NSRect)rect


### PR DESCRIPTION
when Horos is in the background (maybe partially occluded) and you click on the Database button in the ViewerController all the windows close, but Horos does not show the Database (or it does not bring it to the foreground if it is already open), here is a fix for that

do you know if this breaks anything?