### PR TITLE
Bug fix for a type of OutOfResourcesSubOperations errors

### DIFF
--- a/Binaries/dcmtk-source/dcmdata/dcuid.cc
+++ b/Binaries/dcmtk-source/dcmdata/dcuid.cc
@@ -427,7 +427,7 @@ const char* dcmAllStorageSOPClassUIDs[] =
     UID_DigitalXRayImageStorageForPresentation,
     UID_DigitalXRayImageStorageForProcessing,
     UID_EncapsulatedPDFStorage,
-    UID_EncapsulatedCDAStorage
+    UID_EncapsulatedCDAStorage,
     UID_EnhancedCTImageStorage,
 	UID_EnhancedPETImageStorage,
     UID_EnhancedMRImageStorage,
@@ -534,7 +534,7 @@ const char* dcmLongSCUStorageSOPClassUIDs[] =
     UID_DigitalXRayImageStorageForPresentation,
     UID_DigitalXRayImageStorageForProcessing,
     UID_EncapsulatedPDFStorage,
-    UID_EncapsulatedCDAStorage
+    UID_EncapsulatedCDAStorage,
     UID_EnhancedCTImageStorage,
 	UID_EnhancedPETImageStorage,
     UID_EnhancedMRImageStorage,


### PR DESCRIPTION
Bug fix for OutOfResourcesSubOperations errors due to no Presentation Context accepted. Now UID_EncapsulatedCDAStorage and UID_EnhancedCTImageStorage are correctly accepted.

Related to #121