### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ### Prerequisites
 
-1. `cmake` and `pkg-config` must be in the system's `PATH`.
-2. `git-lfs` must be in the installed (for VTK-m) (https://git-lfs.github.com/) 
-3. Patience and coffee. A full build takes about 30-45 minutes.
+1. Must use XCode 11.3.1, due to runtime errors this will NOT work with versions above.  You can download this here: https://developer.apple.com/download/more/?q=xcode (requires being signed in to your developer account to view)
+2. In XCode 11.3.1, set your command line tools to 12.1 or higher (This prevents OpenSSL from complaining during compilation with linker errors).  You can do this in XCode by going to preferences -> locations and setting the command line tool version.
+3. `cmake` and `pkg-config` must be in the system's `PATH`.
+4. `git-lfs` must be in the installed (for VTK-m) (https://git-lfs.github.com/) 
+5. Patience and coffee. A full build takes about 30-45 minutes.
 
 ### Build
 


### PR DESCRIPTION
Xcode 11.3.1 is REQUIRED to make this run currently due to memory access errors.  It is possible to compile with a higher Xcode but you will get runtime errors making it useless currently.  This should be stated in the readme for new users compiling.  Also the command line tools must be set to 12.1 or openSSL will fail to compile as well.